### PR TITLE
feat(provider): add environment variable support for organization config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ CleverCloud provider allow you to interact with CleverCloud platform.
 
 ### Required
 
-- `organisation` (String, Sensitive) CleverCloud organisation, can be either orga_xxx, or user_xxx for personal spaces
+- `organisation` (String, Sensitive) CleverCloud organisation, can be either orga_xxx, or user_xxx for personal spaces. This parameter can also be provided via CC_ORGANISATION environment variable.
 
 ### Optional
 

--- a/pkg/provider/impl/provider_configure.go
+++ b/pkg/provider/impl/provider_configure.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -20,7 +21,11 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		return
 	}
 
-	p.organization = config.Organisation.ValueString()
+	if config.Organisation.IsUnknown() || config.Organisation.IsNull() {
+		p.organization = os.Getenv("CC_ORGANISATION")
+	} else {
+		p.organization = config.Organisation.ValueString()
+	}
 
 	// Allow to get creds from CLI config directory or by injected variables
 	if config.Secret.IsUnknown() ||

--- a/pkg/provider/impl/provider_schema.go
+++ b/pkg/provider/impl/provider_schema.go
@@ -45,7 +45,7 @@ func (p *Provider) Schema(_ context.Context, req provider.SchemaRequest, res *pr
 			"organisation": schema.StringAttribute{
 				Sensitive:           true,
 				Required:            true,
-				MarkdownDescription: "CleverCloud organisation, can be either orga_xxx, or user_xxx for personal spaces",
+				MarkdownDescription: "CleverCloud organisation, can be either orga_xxx, or user_xxx for personal spaces. This parameter can also be provided via CC_ORGANISATION environment variable.",
 				Validators: []validator.String{
 					pkg.NewValidatorRegex("valid owner name", regexp.MustCompile(`^(user|orga)_.{36}`)),
 				},


### PR DESCRIPTION
Hi there 👋

Here is another contribution, to make the organization configurable by an environment variable named `CC_ORGANIZATION`.

I also corrected the english spelling of _organization_.

This is separated in two commits :

- fix(provider): correct typo in provider configuration variable
- feat(provider): add environment variable support for organization config
