### PR TITLE
ci(changelog.skip): since v1.24 skip->disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,4 +51,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
https://goreleaser.com/deprecations/#changelogskip