### PR TITLE
feat(postgresql): allow to disable backups

### DIFF
--- a/docs/resources/postgresql.md
+++ b/docs/resources/postgresql.md
@@ -32,6 +32,7 @@ resource "clevercloud_postgresql" "postgresql_database" {
 
 ### Optional
 
+- `backup` (Boolean) Enable or disable backups for this PostgreSQL addon. Since backups are included in the addon price, disabling it has no impact on your billing.
 - `region` (String) Geographical region where the data will be stored
 - `version` (String) PostgreSQL version
 

--- a/pkg/resources/postgresql/postgresql_test.go
+++ b/pkg/resources/postgresql/postgresql_test.go
@@ -38,6 +38,7 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 			"name":   rName,
 			"region": "par",
 			"plan":   "dev",
+			"backup": true,
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -75,6 +76,7 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 				resource.TestMatchResourceAttr(fullName, "user", regexp.MustCompile(`^[a-zA-Z0-9]+$`)),
 				resource.TestMatchResourceAttr(fullName, "password", regexp.MustCompile(`^[a-zA-Z0-9]+$`)),
 				resource.TestCheckResourceAttr(fullName, "plan", "dev"),
+				resource.TestCheckResourceAttr(fullName, "backup", "true"),
 			),
 		}, {
 			ResourceName: rName2,
@@ -86,6 +88,7 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 					"region":  "par",
 					"plan":    "xs_sml",
 					"version": "17",
+					"backup":  true,
 				}))).String(),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestMatchResourceAttr(fullName2, "id", regexp.MustCompile(`^addon_.*`)),
@@ -96,6 +99,7 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 				resource.TestMatchResourceAttr(fullName2, "password", regexp.MustCompile(`^[a-zA-Z0-9]+$`)),
 				resource.TestCheckResourceAttr(fullName2, "plan", "xs_sml"),
 				resource.TestCheckResourceAttr(fullName2, "version", "17"),
+				resource.TestCheckResourceAttr(fullName2, "backup", "true"),
 			),
 		}, /*{
 			ResourceName: rName3,

--- a/pkg/resources/postgresql/schema.go
+++ b/pkg/resources/postgresql/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.clever-cloud.com/terraform-provider/pkg"
@@ -24,6 +25,7 @@ type PostgreSQL struct {
 	User     types.String `tfsdk:"user"`
 	Password types.String `tfsdk:"password"`
 	Version  types.String `tfsdk:"version"`
+	Backup   types.Bool   `tfsdk:"backup"`
 }
 
 //go:embed doc.md
@@ -46,6 +48,12 @@ func (r ResourcePostgreSQL) Schema(_ context.Context, req resource.SchemaRequest
 				Validators: []validator.String{
 					pkg.NewStringValidator("Match existing PostgresQL version", r.validatePGVersion),
 				},
+			},
+			"backup": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Enable or disable backups for this PostgreSQL addon. Since backups are included in the addon price, disabling it has no impact on your billing.",
 			},
 		}),
 	}

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -55,10 +55,16 @@ type PostgreSQL struct {
 	Plan     string `json:"plan" example:"xs_med"`
 	Port     int    `json:"port" example:"6388"`
 	// read_only_users:[]
-	Status  string `json:"status" example:"ACTIVE"`
-	User    string `json:"user" example:"uxw1ikwnp6gflbgp5iun"`
-	Version string `json:"version"` // 14
-	Zone    string `json:"zone" example:"par"`
+	Status   string              `json:"status" example:"ACTIVE"`
+	User     string              `json:"user" example:"uxw1ikwnp6gflbgp5iun"`
+	Version  string              `json:"version"` // 14
+	Zone     string              `json:"zone" example:"par"`
+	Features []PostgreSQLFeature `json:"features"`
+}
+
+type PostgreSQLFeature struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
 }
 
 func GetAddonsProviders(ctx context.Context, cc *client.Client) client.Response[[]AddonProvider] {


### PR DESCRIPTION
## Context

Introduce a new parameter to disable backup of postgresql addons when backups are not available or when not needed.

## Test

```
resource "clevercloud_postgresql" "my_db" {
  name   = "my_db"
  plan   = "xxs_sml"
  region = var.cc_global_zone
  backup = false
}
```