### PR TITLE
Add missing dependencies link to various runtimes

### DIFF
--- a/pkg/resources/docker/crud.go
+++ b/pkg/resources/docker/crud.go
@@ -56,6 +56,12 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -76,9 +82,10 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)

--- a/pkg/resources/java/crud.go
+++ b/pkg/resources/java/crud.go
@@ -54,6 +54,12 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -74,9 +80,10 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)

--- a/pkg/resources/php/crud.go
+++ b/pkg/resources/php/crud.go
@@ -55,6 +55,12 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -75,9 +81,10 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)

--- a/pkg/resources/play2/crud.go
+++ b/pkg/resources/play2/crud.go
@@ -54,6 +54,12 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -74,9 +80,10 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)

--- a/pkg/resources/scala/crud.go
+++ b/pkg/resources/scala/crud.go
@@ -56,6 +56,12 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -76,9 +82,10 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)

--- a/pkg/resources/static/crud.go
+++ b/pkg/resources/static/crud.go
@@ -56,6 +56,12 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	dependencies := []string{}
+	resp.Diagnostics.Append(plan.Dependencies.ElementsAs(ctx, &dependencies, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createAppReq := application.CreateReq{
 		Client:       r.cc,
 		Organization: r.org,
@@ -76,9 +82,10 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: environment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  environment,
+		VHosts:       vhosts,
+		Deployment:   plan.toDeployment(r.gitAuth),
+		Dependencies: dependencies,
 	}
 
 	createAppRes, diags := application.CreateApp(ctx, createAppReq)


### PR DESCRIPTION
Some runtimes didn't link the declared `dependencies = [ ... ]` because the variable wasn't propagated on them.