### PR TITLE
fix(creation): fix condition to check if app needs to be restarted

### DIFF
--- a/pkg/application/creation.go
+++ b/pkg/application/creation.go
@@ -168,7 +168,7 @@ func UpdateApp(ctx context.Context, req UpdateReq) (*CreateRes, diag.Diagnostics
 	// error id 4014 = cannot redeploy an application which has never been deployed yet (did you git push?)
 	if req.TriggerRestart {
 		restartRes := tmp.RestartApp(ctx, req.Client, req.Organization, res.Application.ID)
-		if restartRes.HasError(); !strings.Contains(restartRes.Error().Error(), "4014") {
+		if restartRes.HasError() && !strings.Contains(restartRes.Error().Error(), "4014") {
 			diags.AddError("failed to restart app", restartRes.Error().Error())
 			return nil, diags
 		}


### PR DESCRIPTION
Fixes

```
Stack trace from the terraform-provider-clevercloud_v0.11.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xdce82c]

goroutine 97 [running]:
go.clever-cloud.com/terraform-provider/pkg/application.UpdateApp({_, _}, {{0xc000042a20, 0x28}, 0xc000067ec0, {0xc0000426c0, 0x29}, {{0xc00057c2a0, 0x1e}, {0x110dc51, ...}, ...}, ...})
        go.clever-cloud.com/terraform-provider/pkg/application/creation.go:171 +0xbcc
go.clever-cloud.com/terraform-provider/pkg/resources/play2.(*ResourcePlay2).Update(0xc0000a8d80, {0x12db8c8, 0xc000550de0}, {{{{0x12e3f70, 0xc000931470}, {0xfb0fc0, 0xc0000b7e30}}, {0x12e6558, 0xc0009087d0}}, {{{0x12e3f70, ...}, ...}, ...}, ...}, ...)
        go.clever-cloud.com/terraform-provider/pkg/resources/play2/crud.go:230 +0x888
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).UpdateResource(0xc0001ac288, {0x12db8c8, 0xc000550de0}, 0xc0006653a8, 0xc000665378)
        github.com/hashicorp/terraform-plugin-framework@v1.15.0/internal/fwserver/server_updateresource.go:150 +0x9ad
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0xc0001ac288, {0x12db8c8, 0xc000550de0}, 0xc0004040e0, 0xc0006655e8)
        github.com/hashicorp/terraform-plugin-framework@v1.15.0/internal/fwserver/server_applyresourcechange.go:118 +0x1cc
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0xc0001ac288, {0x12db8c8?, 0xc000550cf0?}, 0xc0009a6a50)
        github.com/hashicorp/terraform-plugin-framework@v1.15.0/internal/proto6server/server_applyresourcechange.go:71 +0x585
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc0000da140, {0x12db8c8?, 0xc000550210?}, 0xc0000dc200)
        github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/tf6server/server.go:941 +0x3b9
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x10ed2a0, 0xc0000da140}, {0x12db8c8, 0xc000550210}, 0xc0000dc180, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:687 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00002a000, {0x12db8c8, 0xc000550180}, 0xc000b0a000, 0xc0000b70b0, 0x1ac0468, 0x0)
        google.golang.org/grpc@v1.72.1/server.go:1405 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc00002a000, {0x12dc880, 0xc0000fa340}, 0xc000b0a000)
        google.golang.org/grpc@v1.72.1/server.go:1815 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.72.1/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 15
        google.golang.org/grpc@v1.72.1/server.go:1046 +0x11d

Error: The terraform-provider-clevercloud_v0.11.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```