### PR TITLE
fix(runtime): add missing Dependencies field in all runtime Update methods

### DIFF
--- a/pkg/resources/docker/crud.go
+++ b/pkg/resources/docker/crud.go
@@ -191,6 +191,7 @@ func (r *ResourceDocker) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -216,6 +217,7 @@ func (r *ResourceDocker) Update(ctx context.Context, req resource.UpdateRequest,
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/frankenphp/crud.go
+++ b/pkg/resources/frankenphp/crud.go
@@ -179,6 +179,7 @@ func (r *ResourceFrankenPHP) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	updateAppReq := application.UpdateReq{
 		ID:           state.ID.ValueString(),
@@ -200,9 +201,10 @@ func (r *ResourceFrankenPHP) Update(ctx context.Context, req resource.UpdateRequ
 			Zone:            plan.Region.ValueString(),
 			CancelOnPush:    false,
 		},
-		Environment: planEnvironment,
-		VHosts:      vhosts,
-		Deployment:  plan.toDeployment(r.gitAuth),
+		Environment:  planEnvironment,
+		VHosts:       vhosts,
+		Dependencies: dependencies,
+		Deployment:   plan.toDeployment(r.gitAuth),
 	}
 
 	updateAppRes, diags := application.UpdateApp(ctx, updateAppReq)

--- a/pkg/resources/golang/crud.go
+++ b/pkg/resources/golang/crud.go
@@ -194,6 +194,7 @@ func (r *ResourceGo) Update(ctx context.Context, req resource.UpdateRequest, res
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -219,6 +220,7 @@ func (r *ResourceGo) Update(ctx context.Context, req resource.UpdateRequest, res
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/java/crud.go
+++ b/pkg/resources/java/crud.go
@@ -199,6 +199,7 @@ func (r *ResourceJava) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -224,6 +225,7 @@ func (r *ResourceJava) Update(ctx context.Context, req resource.UpdateRequest, r
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/nodejs/crud.go
+++ b/pkg/resources/nodejs/crud.go
@@ -192,6 +192,7 @@ func (r *ResourceNodeJS) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -217,6 +218,7 @@ func (r *ResourceNodeJS) Update(ctx context.Context, req resource.UpdateRequest,
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/php/crud.go
+++ b/pkg/resources/php/crud.go
@@ -187,6 +187,7 @@ func (r *ResourcePHP) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	updateAppReq := application.UpdateReq{
 		ID:           state.ID.ValueString(),
@@ -211,6 +212,7 @@ func (r *ResourcePHP) Update(ctx context.Context, req resource.UpdateRequest, re
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/play2/crud.go
+++ b/pkg/resources/play2/crud.go
@@ -198,6 +198,7 @@ func (r *ResourcePlay2) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -223,6 +224,7 @@ func (r *ResourcePlay2) Update(ctx context.Context, req resource.UpdateRequest, 
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/python/crud.go
+++ b/pkg/resources/python/crud.go
@@ -183,6 +183,7 @@ func (r *ResourcePython) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -208,6 +209,7 @@ func (r *ResourcePython) Update(ctx context.Context, req resource.UpdateRequest,
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/rust/crud.go
+++ b/pkg/resources/rust/crud.go
@@ -178,6 +178,7 @@ func (r *ResourceRust) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Retrieve instance of the app from context
 	instance := application.LookupInstanceByVariantSlug(ctx, r.cc, nil, "rust", res.Diagnostics)
@@ -218,6 +219,7 @@ func (r *ResourceRust) Update(ctx context.Context, req resource.UpdateRequest, r
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/scala/crud.go
+++ b/pkg/resources/scala/crud.go
@@ -201,6 +201,7 @@ func (r *ResourceScala) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -226,6 +227,7 @@ func (r *ResourceScala) Update(ctx context.Context, req resource.UpdateRequest, 
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}

--- a/pkg/resources/static/crud.go
+++ b/pkg/resources/static/crud.go
@@ -200,6 +200,7 @@ func (r *ResourceStatic) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Same as env but with vhosts
 	vhosts := plan.VHostsAsStrings(ctx, &res.Diagnostics)
+	dependencies := plan.DependenciesAsString(ctx, &res.Diagnostics)
 
 	// Get the updated values from plan and instance
 	updateAppReq := application.UpdateReq{
@@ -225,6 +226,7 @@ func (r *ResourceStatic) Update(ctx context.Context, req resource.UpdateRequest,
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
+		Dependencies:   dependencies,
 		Deployment:     plan.toDeployment(r.gitAuth),
 		TriggerRestart: !reflect.DeepEqual(planEnvironment, stateEnvironment),
 	}


### PR DESCRIPTION
All runtime resources (Docker, FrankenPHP, Go, Java WAR, Node.js, PHP, Play2, Python, Rust, Scala, Static) were missing the Dependencies field in their Update methods, causing dependency updates to be silently ignored.

This prevented users from adding or modifying dependencies (like Redis, PostgreSQL, etc.) to existing applications through Terraform updates.