### PR TITLE
fix(bin): by default, provide a stripped binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ OS_ARCH=linux_amd64
 TAG_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
 TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
 COMMIT := $(shell git rev-parse --short HEAD)
+LDFLAGS := -s -w
 
 ifndef VERSION
 	ifeq ($(COMMIT), $(TAG_COMMIT))
@@ -19,7 +20,7 @@ endif
 default: install
 
 build:
-	go build -o ${BINARY}
+	go build -ldflags "${LDFLAGS}" -o ${BINARY}
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Set the following environment variables:
 
 ```bash
 export CLEVER_TOKEN="your-clever-cloud-token"
-export CLEVER_SECRET="your-clever-cloud-secret" 
+export CLEVER_SECRET="your-clever-cloud-secret"
 export ORGANISATION="your-organization-id"  # Optional, for multi-org accounts
 ```
 
@@ -26,6 +26,20 @@ Run the following command to build the provider
 
 ```shell
 $ go build -o terraform-provider-clevercloud
+```
+
+## Build and install the provider
+
+Run the following command to build and install the provider in the current user's terraform plugin directory
+
+```shell
+$ make
+```
+
+To produce an unstripped binary (for debugging purpose), override `LDFLAGS` with an empty value:
+
+```shell
+$ make LDFLAGS=""
 ```
 
 ## Examples
@@ -72,7 +86,7 @@ provider_installation {
     dev_overrides {
         "CleverCloud/clevercloud" = "/home/[USER]/.terraform.d/plugins/registry.terraform.io/CleverCloud/clevercloud/dev/linux_amd64"
     }
-    
+
     direct{}
 }
 ```


### PR DESCRIPTION
Without the ldflags, the binary is not stripped.