### PR TITLE
fix: use configured endpoint instead of hardcoded default

### DIFF
--- a/pkg/resources/database/mysql/schema.go
+++ b/pkg/resources/database/mysql/schema.go
@@ -100,6 +100,11 @@ func (r ResourceMySQL) validateMyVersion(ctx context.Context, req validator.Stri
 		return
 	}
 
+	// Skip validation if infos not available (provider not configured yet)
+	if infos == nil {
+		return
+	}
+
 	switch plan {
 	case "dev":
 		cluster := pkg.First(infos.Clusters, func(cluster tmp.MysqlCluster) bool {

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -13,13 +13,16 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/addon"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
-	"go.clever-cloud.dev/client"
 )
 
 func (r *ResourcePostgreSQL) FetchPostgresInfos(ctx context.Context, diags *diag.Diagnostics) {
-	cc := client.New()
+	// Skip fetching during schema validation (before provider is configured)
+	if r.Provider == nil || r.Client() == nil {
+		tflog.Debug(ctx, "Skipping postgres infos fetch - provider not configured yet")
+		return
+	}
 
-	res := tmp.GetPostgresInfos(ctx, cc)
+	res := tmp.GetPostgresInfos(ctx, r.Client())
 	if res.HasError() {
 		tflog.Error(ctx, "failed to get postgres infos", map[string]any{"error": res.Error().Error()})
 		return

--- a/pkg/resources/database/postgresql/schema.go
+++ b/pkg/resources/database/postgresql/schema.go
@@ -81,6 +81,11 @@ func (r ResourcePostgreSQL) validatePGVersion(ctx context.Context, req validator
 		return
 	}
 
+	// Skip validation if infos not available (provider not configured yet)
+	if infos == nil {
+		return
+	}
+
 	switch plan {
 	case "dev":
 		cluster := pkg.First(infos.Clusters, func(cluster tmp.PostgresCluster) bool {


### PR DESCRIPTION
FetchPostgresInfos/FetchMysqlInfos were creating new client with client.New() which uses hardcoded api.clever-cloud.com, ignoring provider endpoint config.

Now uses r.Client() when provider is configured, skips API call during early schema validation to prevent nil pointer dereference.

In some very specific cases (public API is not available), the following error type occured:
```
╷
│ Error: PostgreSQL version not available
│
│   with clevercloud_postgresql.test-terraform-db,
│   on resources.tf line 5, in resource "clevercloud_postgresql" "test-terraform-db":
│    5:   version            = 16
│
│ version 16 not available, available versions:
╵
```

This MR solves this behavior