### PR TITLE
feat(application): add deployed_commit computed attribute

### DIFF
--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -130,6 +130,9 @@ func Read[T RuntimePlan](ctx context.Context, resource RuntimeResource, state T)
 	// Read linked dependencies (addons)
 	runtime.Dependencies = ReadDependencies(ctx, resource.Client(), resource.Organization(), runtime.ID.ValueString(), runtime.Dependencies, &diags)
 
+	// Read deployed commit
+	runtime.DeployedCommit = ReadDeployedCommit(ctx, resource, runtime.ID.ValueString(), &diags)
+
 	// Map environment variables to runtime-specific fields
 	state.FromEnv(ctx, env, &diags)
 

--- a/pkg/resources/application/runtime.go
+++ b/pkg/resources/application/runtime.go
@@ -45,6 +45,7 @@ type Runtime struct {
 	RedirectHTTPS    types.Bool               `tfsdk:"redirect_https"`
 	VHosts           types.Set                `tfsdk:"vhosts"`
 	DeployURL        types.String             `tfsdk:"deploy_url"`
+	DeployedCommit   types.String             `tfsdk:"deployed_commit"`
 	Dependencies     types.Set                `tfsdk:"dependencies"`
 	Networkgroups    types.Set                `tfsdk:"networkgroups"`
 	Deployment       *attributes.Deployment   `tfsdk:"deployment"`

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -129,6 +129,10 @@ var runtimeCommon = map[string]schema.Attribute{
 		MarkdownDescription: "Git URL used to push source code",
 		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
+	"deployed_commit": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The commit hash currently deployed on the application",
+	},
 	"environment": schema.MapAttribute{
 		Optional:            true,
 		Sensitive:           true,


### PR DESCRIPTION
## Summary

- Add a new computed attribute `deployed_commit` to all application resources
- Shows the commit hash of the most recent successful deployment
- Read-only attribute that doesn't cause drift on `deployment.commit`

## Motivation

Closes #100

Users wanted to know what commit is actually deployed on their application. Previously, `deployment.commit` only showed what was *requested* to deploy (e.g., `refs/heads/main`), not the actual deployed commit hash.