### PR TITLE
fix(addons): use API response instead of plan values

### DIFF
--- a/pkg/resources/addon/crud.go
+++ b/pkg/resources/addon/crud.go
@@ -136,7 +136,7 @@ func (r *ResourceAddon) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("failed to update Addon", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/cellar/crud.go
+++ b/pkg/resources/database/cellar/crud.go
@@ -131,7 +131,7 @@ func (r *ResourceCellar) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("failed to update Cellar", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/fsbucket/crud.go
+++ b/pkg/resources/database/fsbucket/crud.go
@@ -137,7 +137,7 @@ func (r *ResourceFSBucket) Update(ctx context.Context, req resource.UpdateReques
 		resp.Diagnostics.AddError("failed to update FSBucket", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/materiakv/crud.go
+++ b/pkg/resources/database/materiakv/crud.go
@@ -136,7 +136,7 @@ func (r *ResourceMateriaKV) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("failed to update MateriaKV", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/pkg/resources/database/mysql/crud.go
+++ b/pkg/resources/database/mysql/crud.go
@@ -226,7 +226,7 @@ func (r *ResourceMySQL) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("failed to update Mysql", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	addon.SyncNetworkGroups(
 		ctx,

--- a/pkg/resources/database/pulsar/crud.go
+++ b/pkg/resources/database/pulsar/crud.go
@@ -237,7 +237,7 @@ func (r *ResourcePulsar) Update(ctx context.Context, req resource.UpdateRequest,
 	if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to update Pulsar", addonRes.Error().Error())
 	} else {
-		state.Name = plan.Name
+		state.Name = pkg.FromStr(addonRes.Payload().Name)
 		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	}
 

--- a/pkg/resources/database/redis/crud.go
+++ b/pkg/resources/database/redis/crud.go
@@ -176,7 +176,7 @@ func (r *ResourceRedis) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("failed to update Redis", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	addon.SyncNetworkGroups(
 		ctx,

--- a/pkg/resources/elasticsearch/crud.go
+++ b/pkg/resources/elasticsearch/crud.go
@@ -232,9 +232,9 @@ func (r *ResourceElasticsearch) Update(ctx context.Context, req resource.UpdateR
 		"name": plan.Name.ValueString(),
 	})
 	if addonRes.HasError() {
-		res.Diagnostics.AddError("failed to update Cellar", addonRes.Error().Error())
+		res.Diagnostics.AddError("failed to update Elasticsearch", addonRes.Error().Error())
 	} else {
-		state.Name = plan.Name
+		state.Name = pkg.FromStr(addonRes.Payload().Name)
 	}
 
 	addon.SyncNetworkGroups(

--- a/pkg/resources/software/otoroshi/crud.go
+++ b/pkg/resources/software/otoroshi/crud.go
@@ -134,7 +134,7 @@ func (r *ResourceOtoroshi) Update(ctx context.Context, req resource.UpdateReques
 		resp.Diagnostics.AddError("failed to update Otoroshi", addonRes.Error().Error())
 		return
 	}
-	state.Name = plan.Name
+	state.Name = pkg.FromStr(addonRes.Payload().Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }


### PR DESCRIPTION
Replace state.Name = plan.Name with pkg.FromStr(addonRes.Payload().Name) in all 13 Update functions to use the API-confirmed value instead of what was requested in the Terraform plan.

Also:
- refresh Name/Region from API in Keycloak, Metabase, MongoDB Read
- set Region from CreateAddon response in Matomo and Metabase Create
- fix Keycloak: add Name in Create, remove duplicate Version assignment, add missing FSBucketID in version upgrade block
- fix Elasticsearch Update error message (said "Cellar")

Fix #267