### PR TITLE
fix(import): allow terraform import on application and addon resources

### DIFF
--- a/docs/resources/addon.md
+++ b/docs/resources/addon.md
@@ -24,13 +24,13 @@ List of available providers:
 ### Required
 
 - `name` (String) Name of the service
-- `plan` (String) Database size and spec (must be lowercase)
-- `third_party_provider` (String) Provider ID
 
 ### Optional
 
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
+- `plan` (String) Database size and spec (must be lowercase)
 - `region` (String) Geographical region where the data will be stored
+- `third_party_provider` (String) Provider ID
 
 ### Read-Only
 

--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -37,15 +37,12 @@ resource "clevercloud_docker" "docker_instance" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `container_port` (Number) Set to custom HTTP port if your Docker container runs on custom port
 - `container_port_tcp` (Number) Set to custom TCP port if your Docker container runs on custom port.
@@ -69,6 +66,8 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `ipv6_cidr` (String) Activate the support of IPv6 with an IPv6 subnet int the docker daemon
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
@@ -76,6 +75,7 @@ environment = { for k, v in {
 - `registry_password` (String, Sensitive) The password of your username
 - `registry_url` (String) The server of your private registry (optional).	Docker’s public registry
 - `registry_user` (String) The username to login to a private registry
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -37,15 +37,12 @@ resource "clevercloud_docker" "docker_instance" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `container_port` (Number) Set to custom HTTP port if your Docker container runs on custom port
 - `container_port_tcp` (Number) Set to custom TCP port if your Docker container runs on custom port.
@@ -69,12 +66,15 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `ipv6_cidr` (String) Activate the support of IPv6 with an IPv6 subnet int the docker daemon
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `registry_password` (String, Sensitive) The password of your username
 - `registry_url` (String) The server of your private registry (optional).	Docker’s public registry
 - `registry_user` (String) The username to login to a private registry
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -81,15 +81,12 @@ resource "clevercloud_dotnet" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -107,12 +104,15 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `profile` (String) Override the build configuration settings in your project. Default: Release
 - `proj` (String) The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension.
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `tfm` (String) Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0
 - `version` (String) Choose the .NET Core version between 6.0, 8.0, 9.0. Default: '8.0'

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -81,15 +81,12 @@ resource "clevercloud_dotnet" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -107,11 +104,14 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `profile` (String) Override the build configuration settings in your project. Default: Release
 - `proj` (String) The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension.
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `tfm` (String) Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0
 - `version` (String) Choose the .NET Core version between 6.0, 8.0, 9.0. Default: '8.0'

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -29,15 +29,12 @@ FrankenPHP is a modern PHP application server, written in Go. It gives superpowe
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -56,9 +53,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -29,15 +29,12 @@ FrankenPHP is a modern PHP application server, written in Go. It gives superpowe
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -56,10 +53,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -85,15 +85,12 @@ resource "clevercloud_go" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,9 +108,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -85,15 +85,12 @@ resource "clevercloud_go" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,10 +108,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/haskell.md
+++ b/docs/resources/haskell.md
@@ -81,15 +81,12 @@ resource "clevercloud_haskell" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -107,10 +104,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `stack_install_command` (String) Only use this variable to override the default `install` Stack step command.
 - `stack_install_dependencies_command` (String) Only use this variable to override the default `install --only-dependencies` Stack step command.
 - `stack_setup_command` (String) Only use this variable to override the default `setup` Stack step command.

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -85,15 +85,12 @@ resource "clevercloud_java_war" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,10 +109,13 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -85,15 +85,12 @@ resource "clevercloud_java_war" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,9 +109,12 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -85,15 +85,12 @@ resource "clevercloud_java_war" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,10 +109,13 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -85,15 +85,12 @@ resource "clevercloud_java_war" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,9 +109,12 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -93,15 +93,12 @@ resource "clevercloud_linux" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_command` (String) The command to run during the build phase.
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
@@ -122,11 +119,14 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `makefile` (String) Custom Makefile name or path.
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `mise_file_path` (String) Custom path for the mise.toml configuration file (relative path).
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `run_command` (String) The command to start your application.
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -93,15 +93,12 @@ resource "clevercloud_linux" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_command` (String) The command to run during the build phase.
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
@@ -122,12 +119,15 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `makefile` (String) Custom Makefile name or path.
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `mise_file_path` (String) Custom path for the mise.toml configuration file (relative path).
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `run_command` (String) The command to start your application.
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/mongodb.md
+++ b/docs/resources/mongodb.md
@@ -20,13 +20,13 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mongo
 ### Required
 
 - `name` (String) Name of the service
-- `plan` (String) Database size and spec (must be lowercase)
 
 ### Optional
 
 - `direct_host_only` (Boolean) Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.
 - `encryption` (Boolean) Encrypt the hard drive at rest
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
+- `plan` (String) Database size and spec (must be lowercase)
 - `region` (String) Geographical region where the data will be stored
 
 ### Read-Only

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -20,7 +20,6 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mysql
 ### Required
 
 - `name` (String) Name of the service
-- `plan` (String) Database size and spec (must be lowercase)
 
 ### Optional
 
@@ -28,6 +27,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mysql
 - `direct_host_only` (Boolean) Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.
 - `encryption` (Boolean) Encrypt the hard drive at rest
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
+- `plan` (String) Database size and spec (must be lowercase)
 - `read_only_users` (Attributes List) MySQL users with read-only access (see [below for nested schema](#nestedatt--read_only_users))
 - `region` (String) Geographical region where the data will be stored
 - `skip_log_bin` (Boolean) Disable binary logging. Saves disk space but prevents point-in-time recovery and replication.

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -85,15 +85,12 @@ resource "clevercloud_nodejs" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,12 +109,15 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `package_manager` (String) Either npm, npm-ci, bun, pnpm, yarn-berry or custom
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `registry` (String) The host of your private repository, available values: github or the registry host
 - `registry_token` (String, Sensitive) Private repository token
+- `smallest_flavor` (String) Smallest instance flavor
 - `start_script` (String) Set custom start script, instead of `npm start`
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -85,15 +85,12 @@ resource "clevercloud_nodejs" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,6 +109,8 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `package_manager` (String) Either npm, npm-ci, bun, pnpm, yarn-berry or custom
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
@@ -119,6 +118,7 @@ environment = { for k, v in {
 - `region` (String) Geographical region where the database will be deployed
 - `registry` (String) The host of your private repository, available values: github or the registry host
 - `registry_token` (String, Sensitive) Private repository token
+- `smallest_flavor` (String) Smallest instance flavor
 - `start_script` (String) Set custom start script, instead of `npm start`
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -22,15 +22,12 @@ See [PHP with Apache product specification](https://www.clever.cloud/developers/
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -49,12 +46,15 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `php_version` (String) PHP version (Default: 8)
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `redis_sessions` (Boolean) Use a linked Redis instance to store sessions (Default: false)
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 - `webroot` (String) Define the DocumentRoot of your project (default: ".")

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -22,15 +22,12 @@ See [PHP with Apache product specification](https://www.clever.cloud/developers/
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -49,11 +46,14 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `php_version` (String) PHP version (Default: 8)
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redis_sessions` (Boolean) Use a linked Redis instance to store sessions (Default: false)
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 - `webroot` (String) Define the DocumentRoot of your project (default: ".")

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -85,15 +85,12 @@ resource "clevercloud_play2" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,9 +108,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -85,15 +85,12 @@ resource "clevercloud_play2" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,10 +108,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/postgresql.md
+++ b/docs/resources/postgresql.md
@@ -28,7 +28,6 @@ resource "clevercloud_postgresql" "postgresql_database" {
 ### Required
 
 - `name` (String) Name of the service
-- `plan` (String) Database size and spec (must be lowercase)
 
 ### Optional
 
@@ -37,6 +36,7 @@ resource "clevercloud_postgresql" "postgresql_database" {
 - `encryption` (Boolean) Encrypt the hard drive at rest
 - `locale` (String) Database locale for collation and character classification. Must be in format 'language_COUNTRY' (e.g., 'en_GB', 'fr_FR'). Only available on dedicated plans. If not specified, defaults to 'en_GB'.
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
+- `plan` (String) Database size and spec (must be lowercase)
 - `region` (String) Geographical region where the data will be stored
 - `version` (String) PostgreSQL version
 

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -85,15 +85,12 @@ resource "clevercloud_python" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,11 +108,14 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `pip_requirements` (String) Define a custom requirements.txt file (default: requirements.txt)
 - `python_version` (String) Python version >= 2.7
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -85,15 +85,12 @@ resource "clevercloud_python" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,12 +108,15 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `pip_requirements` (String) Define a custom requirements.txt file (default: requirements.txt)
 - `python_version` (String) Python version >= 2.7
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -20,11 +20,11 @@ See [Redis product specification](https://www.clever.cloud/developers/doc/addons
 ### Required
 
 - `name` (String) Name of the service
-- `plan` (String) Database size and spec (must be lowercase)
 
 ### Optional
 
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
+- `plan` (String) Database size and spec (must be lowercase)
 - `region` (String) Geographical region where the data will be stored
 
 ### Read-Only

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -156,15 +156,12 @@ resource "clevercloud_ruby" "custom_ruby_app" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -186,6 +183,8 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `http_basic_auth` (String, Sensitive) Restrict HTTP access to your application (format: 'login:password')
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `nginx_proxy_buffer_size` (String) Sets the size of the buffer used for reading the first part of the response received from the proxied server
 - `nginx_proxy_buffers` (String) Sets the number and size of the buffers used for reading a response from the proxied server
@@ -199,6 +198,7 @@ environment = { for k, v in {
 - `region` (String) Geographical region where the database will be deployed
 - `ruby_version` (String) Ruby version to use (e.g., '3.3', '3.3.1')
 - `sidekiq_files` (String) Specify a list of Sidekiq configuration files (e.g., './config/sidekiq_1.yml,./config/sidekiq_2.yml')
+- `smallest_flavor` (String) Smallest instance flavor
 - `static_files_path` (String) Relative path to where your static files are stored
 - `static_url_prefix` (String) The URL path under which you want to serve static files, usually /public
 - `static_webroot` (String) Path to the web content to serve, relative to the root of your application

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -156,15 +156,12 @@ resource "clevercloud_ruby" "custom_ruby_app" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -186,6 +183,8 @@ environment = { for k, v in {
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `http_basic_auth` (String, Sensitive) Restrict HTTP access to your application (format: 'login:password')
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `nginx_proxy_buffer_size` (String) Sets the size of the buffer used for reading the first part of the response received from the proxied server
 - `nginx_proxy_buffers` (String) Sets the number and size of the buffers used for reading a response from the proxied server
@@ -198,6 +197,7 @@ environment = { for k, v in {
 - `region` (String) Geographical region where the database will be deployed
 - `ruby_version` (String) Ruby version to use (e.g., '3.3', '3.3.1')
 - `sidekiq_files` (String) Specify a list of Sidekiq configuration files (e.g., './config/sidekiq_1.yml,./config/sidekiq_2.yml')
+- `smallest_flavor` (String) Smallest instance flavor
 - `static_files_path` (String) Relative path to where your static files are stored
 - `static_url_prefix` (String) The URL path under which you want to serve static files, usually /public
 - `static_webroot` (String) Path to the web content to serve, relative to the root of your application

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -85,15 +85,12 @@ resource "clevercloud_rust" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,9 +109,12 @@ environment = { for k, v in {
 - `features` (Set of String) List of Rust features to enable during build
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -85,15 +85,12 @@ resource "clevercloud_rust" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -112,10 +109,13 @@ environment = { for k, v in {
 - `features` (Set of String) List of Rust features to enable during build
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -85,15 +85,12 @@ resource "clevercloud_scala" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,9 +108,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -85,15 +85,12 @@ resource "clevercloud_scala" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -111,10 +108,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -88,15 +88,12 @@ resource "clevercloud_static" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -114,9 +111,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -88,15 +88,12 @@ resource "clevercloud_static" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -114,10 +111,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -121,15 +121,12 @@ resource "clevercloud_static_apache" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -147,9 +144,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -121,15 +121,12 @@ resource "clevercloud_static_apache" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
@@ -147,10 +144,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -81,15 +81,12 @@ resource "clevercloud_v" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `binary` (String) The name of the output binary file. Default: `${APP_HOME}/v_bin_${APP_ID}`
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
@@ -109,9 +106,12 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -81,15 +81,12 @@ resource "clevercloud_v" "myapp" {
 
 ### Required
 
-- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
-- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
-- `min_instance_count` (Number) Minimum instance count
 - `name` (String) Application name
-- `smallest_flavor` (String) Smallest instance flavor
 
 ### Optional
 
 - `app_folder` (String) Folder in which the application is located (inside the git repository)
+- `biggest_flavor` (String) Biggest instance flavor, if different from smallest, enable auto-scaling
 - `binary` (String) The name of the output binary file. Default: `${APP_HOME}/v_bin_${APP_ID}`
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
@@ -109,10 +106,13 @@ environment = { for k, v in {
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
+- `max_instance_count` (Number) Maximum instance count, if different from min value, enable auto-scaling
+- `min_instance_count` (Number) Minimum instance count
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
+- `smallest_flavor` (String) Smallest instance flavor
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 

--- a/pkg/resources/addon/attributes.go
+++ b/pkg/resources/addon/attributes.go
@@ -24,9 +24,11 @@ var addonCommon = map[string]schema.Attribute{
 	"id":   schema.StringAttribute{Computed: true, MarkdownDescription: "Generated unique identifier", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 	"name": schema.StringAttribute{Required: true, MarkdownDescription: "Name of the service"},
 	"plan": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Database size and spec (must be lowercase)",
 		Validators:          []validator.String{pkg.NewLowercaseValidator()},
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"region": schema.StringAttribute{
 		Optional:            true,

--- a/pkg/resources/addon/schema.go
+++ b/pkg/resources/addon/schema.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -23,7 +25,7 @@ func (r ResourceAddon) Schema(_ context.Context, req resource.SchemaRequest, res
 		Version:             0,
 		MarkdownDescription: resourcePostgresqlDoc,
 		Attributes: WithAddonCommons(map[string]schema.Attribute{
-			"third_party_provider": schema.StringAttribute{Required: true, MarkdownDescription: "Provider ID"},
+			"third_party_provider": schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Provider ID", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			// provider
 			"configurations": schema.MapAttribute{
 				Computed:            true,

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -100,5 +100,7 @@ func (r *ResourceDocker) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "docker", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "docker", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -105,5 +105,7 @@ func (r *ResourceDocker) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "docker", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "docker", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceDotnet) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "dotnet", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "dotnet", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceDotnet) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "dotnet", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "dotnet", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -102,5 +102,7 @@ func (r *ResourceFrankenPHP) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "frankenphp", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "frankenphp", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -107,5 +107,7 @@ func (r *ResourceFrankenPHP) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "frankenphp", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "frankenphp", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceGo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequ
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "go", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "go", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceGo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequ
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "go", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "go", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/haskell/crud.go
+++ b/pkg/resources/application/haskell/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceHaskell) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "haskell", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "haskell", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceJava) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, r.profile, plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, r.profile, &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceJava) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, r.profile, plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, r.profile, &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceLinux) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "linux", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "linux", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceLinux) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "linux", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "linux", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceNodeJS) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "node", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "node", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceNodeJS) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "node", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "node", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -100,5 +100,7 @@ func (r *ResourcePHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "php", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "php", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -105,5 +105,7 @@ func (r *ResourcePHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "php", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "php", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -103,5 +103,7 @@ func (r *ResourcePlay2) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "play2", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "play2", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -108,5 +108,7 @@ func (r *ResourcePlay2) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "play2", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "play2", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -100,5 +100,7 @@ func (r *ResourcePython) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "python", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "python", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -105,5 +105,7 @@ func (r *ResourcePython) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "python", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "python", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/python/python_test.go
+++ b/pkg/resources/application/python/python_test.go
@@ -461,3 +461,66 @@ func TestAccPython_networkgroup(t *testing.T) {
 		}},
 	})
 }
+
+func TestAccPython_import(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-python-import")
+	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
+	cc := client.New(client.WithAutoOauthConfig())
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	pythonBlock := helper.NewRessource(
+		"clevercloud_python",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":               rName,
+			"region":             "par",
+			"min_instance_count": 1,
+			"max_instance_count": 2,
+			"smallest_flavor":    "XS",
+			"biggest_flavor":     "M",
+			"environment": map[string]any{
+				"MY_KEY": "myval",
+			},
+		}),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 tests.ExpectOrganisation(t),
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		CheckDestroy: func(state *terraform.State) error {
+			for _, resource := range state.RootModule().Resources {
+				res := tmp.GetApp(ctx, cc, tests.ORGANISATION, resource.Primary.ID)
+				if res.IsNotFoundError() {
+					continue
+				}
+				if res.HasError() {
+					return fmt.Errorf("unexpected error: %s", res.Error().Error())
+				}
+				if res.Payload().State == "TO_DELETE" {
+					continue
+				}
+
+				return fmt.Errorf("expect resource '%s' to be deleted state: '%s'", resource.Primary.ID, res.Payload().State)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create the resource
+			{
+				ResourceName: rName,
+				Config:       providerBlock.Append(pythonBlock).String(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				},
+			},
+			// Step 2: Import and verify state matches
+			{
+				ResourceName:            fullName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"environment"},
+			},
+		},
+	})
+}

--- a/pkg/resources/application/python/python_test.go
+++ b/pkg/resources/application/python/python_test.go
@@ -462,3 +462,66 @@ func TestAccPython_networkgroup(t *testing.T) {
 		}},
 	})
 }
+
+func TestAccPython_import(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-python-import")
+	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
+	cc := client.New(client.WithAutoOauthConfig())
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	pythonBlock := helper.NewRessource(
+		"clevercloud_python",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":               rName,
+			"region":             "par",
+			"min_instance_count": 1,
+			"max_instance_count": 2,
+			"smallest_flavor":    "XS",
+			"biggest_flavor":     "M",
+			"environment": map[string]any{
+				"MY_KEY": "myval",
+			},
+		}),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 tests.ExpectOrganisation(t),
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		CheckDestroy: func(state *terraform.State) error {
+			for _, resource := range state.RootModule().Resources {
+				res := tmp.GetApp(ctx, cc, tests.ORGANISATION, resource.Primary.ID)
+				if res.IsNotFoundError() {
+					continue
+				}
+				if res.HasError() {
+					return fmt.Errorf("unexpected error: %s", res.Error().Error())
+				}
+				if res.Payload().State == "TO_DELETE" {
+					continue
+				}
+
+				return fmt.Errorf("expect resource '%s' to be deleted state: '%s'", resource.Primary.ID, res.Payload().State)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create the resource
+			{
+				ResourceName: rName,
+				Config:       providerBlock.Append(pythonBlock).String(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				},
+			},
+			// Step 2: Import and verify state matches
+			{
+				ResourceName:            fullName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"environment"},
+			},
+		},
+	})
+}

--- a/pkg/resources/application/python/python_test.go
+++ b/pkg/resources/application/python/python_test.go
@@ -469,58 +469,91 @@ func TestAccPython_import(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-python-import")
 	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
 	cc := client.New(client.WithAutoOauthConfig())
+
+	var appID string
+
 	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	// min_instance_count and max_instance_count are deliberately omitted: they used
+	// to be Required, which made `terraform import` fail before the config was even
+	// read. Leaving them out is what the import path must now support.
 	pythonBlock := helper.NewRessource(
 		"clevercloud_python",
 		rName,
 		helper.SetKeyValues(map[string]any{
-			"name":               rName,
-			"region":             "par",
-			"min_instance_count": 1,
-			"max_instance_count": 2,
-			"smallest_flavor":    "XS",
-			"biggest_flavor":     "M",
-			"environment": map[string]any{
-				"MY_KEY": "myval",
-			},
+			"name":            rName,
+			"region":          "par",
+			"smallest_flavor": "XS",
+			"biggest_flavor":  "M",
+			// The platform injects CC_PYTHON_VERSION on its own and Read() maps it
+			// back to python_version, which is Optional without Computed: leaving it
+			// out of the config would plan it back to null on every run.
+			"python_version": "3",
 		}),
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 tests.ExpectOrganisation(t),
 		ProtoV6ProviderFactories: tests.ProtoV6Provider,
-		CheckDestroy: func(state *terraform.State) error {
-			for _, resource := range state.RootModule().Resources {
-				res := tmp.GetApp(ctx, cc, tests.ORGANISATION, resource.Primary.ID)
-				if res.IsNotFoundError() {
-					continue
-				}
-				if res.HasError() {
-					return fmt.Errorf("unexpected error: %s", res.Error().Error())
-				}
-				if res.Payload().State == "TO_DELETE" {
-					continue
-				}
-
-				return fmt.Errorf("expect resource '%s' to be deleted state: '%s'", resource.Primary.ID, res.Payload().State)
-			}
-			return nil
-		},
+		CheckDestroy:             tests.CheckDestroy(ctx),
 		Steps: []resource.TestStep{
-			// Step 1: Create the resource
 			{
-				ResourceName: rName,
-				Config:       providerBlock.Append(pythonBlock).String(),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				// Create the application through the API so Terraform has no prior
+				// state: Read() has to rebuild every attribute from the platform,
+				// which is the scenario issue #134 breaks on.
+				PreConfig: func() {
+					instancesRes := tmp.GetProductInstance(ctx, cc, nil)
+					if instancesRes.HasError() {
+						t.Fatalf("failed to get product instances: %s", instancesRes.Error())
+					}
+					instance := pkg.First(*instancesRes.Payload(), func(i tmp.ProductInstance) bool {
+						return strings.EqualFold(i.Variant.Slug, "python")
+					})
+					if instance == nil {
+						t.Fatal("no product instance matching variant slug 'python'")
+					}
+
+					res := tmp.CreateAppWithRetry(ctx, cc, tests.ORGANISATION, tmp.CreateAppRequest{
+						Name:            rName,
+						Deploy:          "git",
+						InstanceType:    instance.Type,
+						InstanceVariant: instance.Variant.ID,
+						InstanceVersion: instance.Version,
+						MinFlavor:       "XS",
+						MaxFlavor:       "M",
+						MinInstances:    1,
+						MaxInstances:    1,
+						Zone:            "par",
+						// The API rejects an empty forceHttps. "DISABLED" is what the
+						// provider sends for the schema default redirect_https = false,
+						// so the imported state matches the config on the PlanOnly step.
+						ForceHttps: "DISABLED",
+					})
+					if res.HasError() {
+						t.Fatalf("failed to create python app: %s", res.Error())
+					}
+					appID = res.Payload().ID
+
+					envRes := tmp.UpdateAppEnv(ctx, cc, tests.ORGANISATION, appID, map[string]string{
+						"CC_PYTHON_VERSION": "3",
+					}, false)
+					if envRes.HasError() {
+						t.Fatalf("failed to set app environment: %s", envRes.Error())
+					}
+				},
+				Config:             providerBlock.Append(pythonBlock).String(),
+				ResourceName:       fullName,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
+					return appID, nil
 				},
 			},
-			// Step 2: Import and verify state matches
 			{
-				ResourceName:            fullName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"environment"},
+				// Re-plan the same config on the imported state. Any attribute that
+				// Read() left null shows up here as a diff, and the ones carrying
+				// RequiresReplace would plan a destroy of the imported application.
+				Config:   providerBlock.Append(pythonBlock).String(),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceRuby) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "ruby", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "ruby", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceRuby) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "ruby", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "ruby", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -100,5 +100,7 @@ func (r *ResourceRust) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "rust", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "rust", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -105,5 +105,7 @@ func (r *ResourceRust) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "rust", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "rust", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceScala) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "sbt", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "sbt", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceScala) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "sbt", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "sbt", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -31,21 +32,29 @@ var runtimeCommon = map[string]schema.Attribute{
 		MarkdownDescription: "Application description",
 	},
 	"min_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Minimum instance count",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 		//Default:             int64default.StaticInt64(1), // TODO: setup all defaults
 	},
 	"max_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Maximum instance count, if different from min value, enable auto-scaling",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 	},
 	"smallest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Smallest instance flavor",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"biggest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Biggest instance flavor, if different from smallest, enable auto-scaling",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"build_flavor": schema.StringAttribute{
 		Optional:            true,
@@ -204,21 +213,29 @@ var runtimeCommonV0 = map[string]schema.Attribute{
 		MarkdownDescription: "Application description",
 	},
 	"min_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Minimum instance count",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 		//Default:             int64default.StaticInt64(1), // TODO: setup all defaults
 	},
 	"max_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Maximum instance count, if different from min value, enable auto-scaling",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 	},
 	"smallest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Smallest instance flavor",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"biggest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Biggest instance flavor, if different from smallest, enable auto-scaling",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"build_flavor": schema.StringAttribute{
 		Optional:            true,

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -328,20 +328,41 @@ func WithRuntimeCommonsV0(runtimeSpecifics map[string]schema.Attribute) map[stri
 	return pkg.Merge(runtimeCommonV0, runtimeSpecifics)
 }
 
-// ValidateRuntimeFlavors validates that build_flavor, smallest_flavor, and biggest_flavor
-// are valid for the given application variant (docker, nodejs, etc.)
-func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlug string, runtime Runtime, diags *diag.Diagnostics) {
+// DefaultAndValidateRuntimePlan sets dynamic defaults for Optional+Computed fields
+// and validates that flavor values are valid for the given application variant.
+// It modifies runtime in place and returns true if the plan was modified.
+func DefaultAndValidateRuntimePlan(ctx context.Context, r provider.Provider, variantSlug string, runtime *Runtime, diags *diag.Diagnostics) (modified bool) {
 	org := r.Organization()
 	instance := LookupInstanceByVariantSlug(ctx, r.Client(), &org, variantSlug, diags)
 	if instance == nil {
 		diags.AddError("failed to lookup instance", fmt.Sprintf("no instance named '%s'", variantSlug))
-		return
+		return false
 	}
-	flavorSet := instance.Flavors.NamesAsSet()
 
+	// Set defaults for unset fields
+	defaultFlavor := instance.DefaultFlavor.Name
+
+	if runtime.MinInstanceCount.IsNull() || runtime.MinInstanceCount.IsUnknown() {
+		runtime.MinInstanceCount = types.Int64Value(1)
+		modified = true
+	}
+	if runtime.MaxInstanceCount.IsNull() || runtime.MaxInstanceCount.IsUnknown() {
+		runtime.MaxInstanceCount = types.Int64Value(1)
+		modified = true
+	}
+	if runtime.SmallestFlavor.IsNull() || runtime.SmallestFlavor.IsUnknown() {
+		runtime.SmallestFlavor = types.StringValue(defaultFlavor)
+		modified = true
+	}
+	if runtime.BiggestFlavor.IsNull() || runtime.BiggestFlavor.IsUnknown() {
+		runtime.BiggestFlavor = types.StringValue(defaultFlavor)
+		modified = true
+	}
+
+	// Validate flavors
+	flavorSet := instance.Flavors.NamesAsSet()
 	availableFlavors := strings.Join(flavorSet.Slice(), ", ")
 
-	// Validate build_flavor
 	if !runtime.BuildFlavor.IsNull() && !runtime.BuildFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.BuildFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -351,8 +372,6 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
-
-	// Validate smallest_flavor
 	if !runtime.SmallestFlavor.IsNull() && !runtime.SmallestFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.SmallestFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -362,8 +381,6 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
-
-	// Validate biggest_flavor
 	if !runtime.BiggestFlavor.IsNull() && !runtime.BiggestFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.BiggestFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -373,4 +390,7 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
+
+	return modified
 }
+

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -32,21 +33,29 @@ var runtimeCommon = map[string]schema.Attribute{
 		MarkdownDescription: "Application description",
 	},
 	"min_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Minimum instance count",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 		//Default:             int64default.StaticInt64(1), // TODO: setup all defaults
 	},
 	"max_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Maximum instance count, if different from min value, enable auto-scaling",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 	},
 	"smallest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Smallest instance flavor",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"biggest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Biggest instance flavor, if different from smallest, enable auto-scaling",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"build_flavor": schema.StringAttribute{
 		Optional:            true,
@@ -204,21 +213,29 @@ var runtimeCommonV0 = map[string]schema.Attribute{
 		MarkdownDescription: "Application description",
 	},
 	"min_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Minimum instance count",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 		//Default:             int64default.StaticInt64(1), // TODO: setup all defaults
 	},
 	"max_instance_count": schema.Int64Attribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Maximum instance count, if different from min value, enable auto-scaling",
+		PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 	},
 	"smallest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Smallest instance flavor",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"biggest_flavor": schema.StringAttribute{
-		Required:            true,
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Biggest instance flavor, if different from smallest, enable auto-scaling",
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 	},
 	"build_flavor": schema.StringAttribute{
 		Optional:            true,

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -328,20 +328,41 @@ func WithRuntimeCommonsV0(runtimeSpecifics map[string]schema.Attribute) map[stri
 	return pkg.Merge(runtimeCommonV0, runtimeSpecifics)
 }
 
-// ValidateRuntimeFlavors validates that build_flavor, smallest_flavor, and biggest_flavor
-// are valid for the given application variant (docker, nodejs, etc.)
-func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlug string, runtime Runtime, diags *diag.Diagnostics) {
+// DefaultAndValidateRuntimePlan sets dynamic defaults for Optional+Computed fields
+// and validates that flavor values are valid for the given application variant.
+// It modifies runtime in place and returns true if the plan was modified.
+func DefaultAndValidateRuntimePlan(ctx context.Context, r provider.Provider, variantSlug string, runtime *Runtime, diags *diag.Diagnostics) (modified bool) {
 	org := r.Organization()
 	instance := LookupInstanceByVariantSlug(ctx, r.Client(), &org, variantSlug, diags)
 	if instance == nil {
 		diags.AddError("failed to lookup instance", fmt.Sprintf("no instance named '%s'", variantSlug))
-		return
+		return false
 	}
-	flavorSet := instance.Flavors.NamesAsSet()
 
+	// Set defaults for unset fields
+	defaultFlavor := instance.DefaultFlavor.Name
+
+	if runtime.MinInstanceCount.IsNull() || runtime.MinInstanceCount.IsUnknown() {
+		runtime.MinInstanceCount = types.Int64Value(1)
+		modified = true
+	}
+	if runtime.MaxInstanceCount.IsNull() || runtime.MaxInstanceCount.IsUnknown() {
+		runtime.MaxInstanceCount = types.Int64Value(1)
+		modified = true
+	}
+	if runtime.SmallestFlavor.IsNull() || runtime.SmallestFlavor.IsUnknown() {
+		runtime.SmallestFlavor = types.StringValue(defaultFlavor)
+		modified = true
+	}
+	if runtime.BiggestFlavor.IsNull() || runtime.BiggestFlavor.IsUnknown() {
+		runtime.BiggestFlavor = types.StringValue(defaultFlavor)
+		modified = true
+	}
+
+	// Validate flavors
+	flavorSet := instance.Flavors.NamesAsSet()
 	availableFlavors := strings.Join(flavorSet.Slice(), ", ")
 
-	// Validate build_flavor
 	if !runtime.BuildFlavor.IsNull() && !runtime.BuildFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.BuildFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -351,8 +372,6 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
-
-	// Validate smallest_flavor
 	if !runtime.SmallestFlavor.IsNull() && !runtime.SmallestFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.SmallestFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -362,8 +381,6 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
-
-	// Validate biggest_flavor
 	if !runtime.BiggestFlavor.IsNull() && !runtime.BiggestFlavor.IsUnknown() {
 		if !flavorSet.Contains(runtime.BiggestFlavor.ValueString()) {
 			diags.AddAttributeError(
@@ -373,4 +390,6 @@ func ValidateRuntimeFlavors(ctx context.Context, r provider.Provider, variantSlu
 			)
 		}
 	}
+
+	return modified
 }

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceStatic) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "static", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "static-apache", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceStatic) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "static", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "static-apache", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceStaticApache) ModifyPlan(ctx context.Context, req resource.Modi
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "static-apache", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "static-apache", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceStaticApache) ModifyPlan(ctx context.Context, req resource.Modi
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "static-apache", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "static-apache", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -103,5 +103,7 @@ func (r *ResourceV) ModifyPlan(ctx context.Context, req resource.ModifyPlanReque
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "v", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "v", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -108,5 +108,7 @@ func (r *ResourceV) ModifyPlan(ctx context.Context, req resource.ModifyPlanReque
 		return
 	}
 
-	application.ValidateRuntimeFlavors(ctx, r, "v", plan.Runtime, &res.Diagnostics)
+	if application.DefaultAndValidateRuntimePlan(ctx, r, "v", &plan.Runtime, &res.Diagnostics) {
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	}
 }


### PR DESCRIPTION
## Summary                                                         
- Change `min_instance_count`, `max_instance_count`, `smallest_flavor`, `biggest_flavor` from `Required` to `Optional + Computed` in application schema
- Change `plan` and `third_party_provider` from `Required` to `Optional + Computed` in addon schema
- Add `UseStateForUnknown()` plan modifiers to prevent drift on imported attributes
- Add `TestAccPython_import` acceptance test

## Context
`terraform import` fails with `Missing Configuration for Required Attribute` because Terraform Plugin Framework validates the HCL config against the schema **before** calling `Read()`. During import there is no config — just an ID — so Required fields without values are rejected.

The fix changes these fields to `Optional + Computed` so the provider can fill them from the API during import. `name` stays `Required` as it's a fundamental identifier the user should always provide.

This is backwards-compatible: existing configs that set these fields explicitly continue to work.

Fix #134