### PR TITLE
fix(apps): guard against empty ID in state on Read and Create

### DIFF
--- a/pkg/resources/addon/crud.go
+++ b/pkg/resources/addon/crud.go
@@ -82,6 +82,11 @@ func (r *ResourceAddon) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	if ad.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), ad.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		req.State.RemoveResource(ctx)

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceDotnet) Create(ctx context.Context, req resource.CreateRequest,
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceFrankenPHP) Create(ctx context.Context, req resource.CreateRequ
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceGo) Create(ctx context.Context, req resource.CreateRequest, res
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceNodeJS) Create(ctx context.Context, req resource.CreateRequest,
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -20,7 +20,10 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -20,7 +20,10 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -20,7 +20,10 @@ func (r *ResourcePython) Create(ctx context.Context, req resource.CreateRequest,
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -48,6 +48,12 @@ func ReadApp(ctx context.Context, cc *client.Client, orgId, appId string) (*Read
 	diags := diag.Diagnostics{}
 	r := &ReadAppRes{}
 
+	// Guard: empty ID means resource was never fully created (fix #351)
+	if appId == "" {
+		r.AppIsDeleted = true
+		return r, diags
+	}
+
 	appRes := tmp.GetApp(ctx, cc, orgId, appId)
 	if appRes.IsNotFoundError() {
 		r.AppIsDeleted = true

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceRuby) Create(ctx context.Context, req resource.CreateRequest, r
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceRust) Create(ctx context.Context, req resource.CreateRequest, r
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -20,7 +20,10 @@ func (r *ResourceV) Create(ctx context.Context, req resource.CreateRequest, resp
 
 	resp.Diagnostics.Append(application.Create(ctx, r, &plan)...)
 
-	// First save: persist ID even if there were partial errors
+	// Only save state if the app was created (has valid ID)
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/resources/configprovider/crud.go
+++ b/pkg/resources/configprovider/crud.go
@@ -85,6 +85,11 @@ func (r *ResourceConfigProvider) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if addonConfigProvider.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonEnvRes := tmp.GetConfigProviderEnv(ctx, r.Client(), r.Organization(), addonConfigProvider.ID.ValueString())
 	if addonEnvRes.HasError() {
 		resp.Diagnostics.AddError("failed to get add-on env", addonEnvRes.Error().Error())

--- a/pkg/resources/database/cellar/bucket/crud.go
+++ b/pkg/resources/database/cellar/bucket/crud.go
@@ -47,6 +47,11 @@ func (r *ResourceCellarBucket) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if cellar.Name.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	// nothing to update yet
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, cellar)...)

--- a/pkg/resources/database/cellar/crud.go
+++ b/pkg/resources/database/cellar/crud.go
@@ -78,6 +78,11 @@ func (r *ResourceCellar) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	if cellar.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), cellar.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)

--- a/pkg/resources/database/fsbucket/crud.go
+++ b/pkg/resources/database/fsbucket/crud.go
@@ -81,6 +81,11 @@ func (r *ResourceFSBucket) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if fsbucket.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), fsbucket.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)

--- a/pkg/resources/database/materiakv/crud.go
+++ b/pkg/resources/database/materiakv/crud.go
@@ -83,6 +83,11 @@ func (r *ResourceMateriaKV) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	if kv.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonKVRes := r.SDK.V4().Materia().
 		Organisations().Ownerid(r.Organization()).Materia().
 		Databases().Resourceid(kv.ID.ValueString()).Getmateriakvv4(ctx)

--- a/pkg/resources/database/mongodb/crud.go
+++ b/pkg/resources/database/mongodb/crud.go
@@ -88,6 +88,11 @@ func (r *ResourceMongoDB) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	if mg.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonId, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), mg.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("failed to get addon ID", err.Error())

--- a/pkg/resources/database/mysql/crud.go
+++ b/pkg/resources/database/mysql/crud.go
@@ -138,6 +138,11 @@ func (r *ResourceMySQL) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	if my.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	// IDs
 	addonId, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), my.ID.ValueString())
 	if err != nil {

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -141,6 +141,11 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	if pg.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	realID, err := tmp.AddonIDToRealID(ctx, r.Client(), r.Organization(), pg.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("failed to get addon ID", err.Error())

--- a/pkg/resources/database/pulsar/crud.go
+++ b/pkg/resources/database/pulsar/crud.go
@@ -89,6 +89,11 @@ func (r *ResourcePulsar) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	pulsarRes := tmp.GetPulsar(ctx, r.Client(), r.Organization(), state.ID.ValueString())
 	if pulsarRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Pulsar", pulsarRes.Error().Error())

--- a/pkg/resources/database/redis/crud.go
+++ b/pkg/resources/database/redis/crud.go
@@ -100,6 +100,11 @@ func (r *ResourceRedis) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	if rd.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), rd.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		diags = resp.State.SetAttribute(ctx, path.Root("id"), types.StringUnknown())

--- a/pkg/resources/drain/crud.go
+++ b/pkg/resources/drain/crud.go
@@ -47,6 +47,11 @@ func (r *ResourceDrain[T]) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if state.GetDrain().ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	// Get drain from API
 	drainRes := tmp.GetDrain(ctx, r.Client(), r.Organization(), state.GetDrain().ResourceID.ValueString(), state.GetDrain().ID.ValueString())
 	if drainRes.HasError() {

--- a/pkg/resources/elasticsearch/crud.go
+++ b/pkg/resources/elasticsearch/crud.go
@@ -108,6 +108,11 @@ func (r *ResourceElasticsearch) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	if identity.ID.ValueString() == "" {
+		res.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), identity.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		res.State.RemoveResource(ctx)

--- a/pkg/resources/kubernetes/crud.go
+++ b/pkg/resources/kubernetes/crud.go
@@ -76,6 +76,11 @@ func (r *ResourceKubernetes) Read(ctx context.Context, req resource.ReadRequest,
 	identity := helper.From[KubernetesIdentity](ctx, req.Identity, &resp.Diagnostics)
 	state := Kubernetes{}
 
+	if identity.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	kubernetesRes := tmp.GetKubernetes(ctx, r.Client(), r.Organization(), identity.ID.ValueString())
 	if kubernetesRes.HasError() {
 		resp.Diagnostics.AddError("Failed to get kubernetes instance", kubernetesRes.Error().Error())

--- a/pkg/resources/kubernetes/nodegroup/crud.go
+++ b/pkg/resources/kubernetes/nodegroup/crud.go
@@ -55,6 +55,11 @@ func (r *ResourceKubernetesNodegroup) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	if identity.ID.ValueString() == "" {
+		res.State.RemoveResource(ctx)
+		return
+	}
+
 	ngRes := r.SDK.V4().Kubernetes().
 		Organisations().Ownerid(r.Organization()).
 		Clusters().Clusterid(state.KubernetesID.ValueString()).

--- a/pkg/resources/networkgroup/crud.go
+++ b/pkg/resources/networkgroup/crud.go
@@ -65,6 +65,11 @@ func (r *ResourceNG) Read(ctx context.Context, req resource.ReadRequest, resp *r
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	ngRes := r.SDK.
 		V4().
 		Networkgroups().

--- a/pkg/resources/software/keycloak/crud.go
+++ b/pkg/resources/software/keycloak/crud.go
@@ -88,6 +88,11 @@ func (r *ResourceKeycloak) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), state.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)

--- a/pkg/resources/software/matomo/crud.go
+++ b/pkg/resources/software/matomo/crud.go
@@ -69,6 +69,11 @@ func (r *ResourceMatomo) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	matomoRes := tmp.GetMatomo(ctx, r.Client(), state.ID.ValueString())
 	if matomoRes.HasError() {
 		resp.Diagnostics.AddError("cannot get matomo", matomoRes.Error().Error())

--- a/pkg/resources/software/metabase/crud.go
+++ b/pkg/resources/software/metabase/crud.go
@@ -67,6 +67,11 @@ func (r *ResourceMetabase) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonMBRes := tmp.GetMetabase(ctx, r.Client(), state.ID.ValueString())
 	if addonMBRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)

--- a/pkg/resources/software/otoroshi/crud.go
+++ b/pkg/resources/software/otoroshi/crud.go
@@ -82,6 +82,11 @@ func (r *ResourceOtoroshi) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	addonRes := tmp.GetAddon(ctx, r.Client(), r.Organization(), state.ID.ValueString())
 	if addonRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)


### PR DESCRIPTION
When application Create fails, the plan struct (with unknown/null ID) was saved to state unconditionally. On the next refresh, the empty ID caused GetApp to hit the LIST endpoint instead of GET-by-ID, resulting in a JSON unmarshal error (array into struct).

Three layers of defense:
- Guard ReadApp against empty appId before API call (fixes #351)
- Condition state save on valid ID in all 14 app runtime Create methods
- Add defensive empty ID guards to Read in all resource types

Fix #351