### PR TITLE
feat(addons): add missing feature flags for MySQL, PostgreSQL, MongoDB

### DIFF
--- a/docs/resources/mongodb.md
+++ b/docs/resources/mongodb.md
@@ -24,6 +24,8 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mongo
 
 ### Optional
 
+- `direct_host_only` (Boolean) Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.
+- `encryption` (Boolean) Encrypt the hard drive at rest
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
 

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -25,9 +25,12 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mysql
 ### Optional
 
 - `backup` (Boolean) Enable or disable backups for this MySQL add-on. Since backups are included in the add-on price, disabling it has no impact on your billing.
+- `direct_host_only` (Boolean) Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.
+- `encryption` (Boolean) Encrypt the hard drive at rest
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `read_only_users` (Attributes List) MySQL users with read-only access (see [below for nested schema](#nestedatt--read_only_users))
 - `region` (String) Geographical region where the data will be stored
+- `skip_log_bin` (Boolean) Disable binary logging. Saves disk space but prevents point-in-time recovery and replication.
 - `version` (String) MySQL version
 
 ### Read-Only

--- a/docs/resources/postgresql.md
+++ b/docs/resources/postgresql.md
@@ -33,7 +33,9 @@ resource "clevercloud_postgresql" "postgresql_database" {
 ### Optional
 
 - `backup` (Boolean) Enable or disable backups for this PostgreSQL add-on. Since backups are included in the add-on price, disabling it has no impact on your billing.
+- `direct_host_only` (Boolean) Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.
 - `encryption` (Boolean) Encrypt the hard drive at rest
+- `locale` (Boolean) Enable locale support for collation and character classification
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
 - `version` (String) PostgreSQL version

--- a/pkg/resources/database/mongodb/crud.go
+++ b/pkg/resources/database/mongodb/crud.go
@@ -37,6 +37,15 @@ func (r *ResourceMongoDB) Create(ctx context.Context, req resource.CreateRequest
 		Plan:       plan.ID,
 		ProviderID: "mongodb-addon",
 		Region:     mg.Region.ValueString(),
+		Options:    map[string]string{},
+	}
+
+	if !mg.Encryption.IsNull() && !mg.Encryption.IsUnknown() {
+		addonReq.Options["encryption"] = fmt.Sprintf("%t", mg.Encryption.ValueBool())
+	}
+
+	if !mg.DirectHostOnly.IsNull() && !mg.DirectHostOnly.IsUnknown() {
+		addonReq.Options["direct-host-only"] = fmt.Sprintf("%t", mg.DirectHostOnly.ValueBool())
 	}
 
 	res := tmp.CreateAddon(ctx, r.Client(), r.Organization(), addonReq)
@@ -67,6 +76,21 @@ func (r *ResourceMongoDB) Create(ctx context.Context, req resource.CreateRequest
 	mg.Password = pkg.FromStr(addonMG.Password)
 	mg.Database = pkg.FromStr(addonMG.Database)
 	mg.Uri = pkg.FromStr(addonMG.Uri())
+
+	if mg.Encryption.IsUnknown() {
+		mg.Encryption = pkg.FromBool(false)
+	}
+	if mg.DirectHostOnly.IsUnknown() {
+		mg.DirectHostOnly = pkg.FromBool(false)
+	}
+	for _, feature := range addonMG.Features {
+		switch feature.Name {
+		case "encryption":
+			mg.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			mg.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		}
+	}
 
 	addon.SyncNetworkGroups(
 		ctx,
@@ -135,6 +159,15 @@ func (r *ResourceMongoDB) Read(ctx context.Context, req resource.ReadRequest, re
 	mg.Password = pkg.FromStr(addonMG.Password)
 	mg.Database = pkg.FromStr(addonMG.Database)
 	mg.Uri = pkg.FromStr(addonMG.Uri())
+
+	for _, feature := range addonMG.Features {
+		switch feature.Name {
+		case "encryption":
+			mg.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			mg.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		}
+	}
 
 	mg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonId, &resp.Diagnostics)
 

--- a/pkg/resources/database/mongodb/schema.go
+++ b/pkg/resources/database/mongodb/schema.go
@@ -6,18 +6,22 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/addon"
 )
 
 type MongoDB struct {
 	addon.CommonAttributes
-	Host     types.String `tfsdk:"host"`
-	Port     types.Int64  `tfsdk:"port"`
-	User     types.String `tfsdk:"user"`
-	Password types.String `tfsdk:"password"`
-	Database types.String `tfsdk:"database"`
-	Uri      types.String `tfsdk:"uri"`
+	Host           types.String `tfsdk:"host"`
+	Port           types.Int64  `tfsdk:"port"`
+	User           types.String `tfsdk:"user"`
+	Password       types.String `tfsdk:"password"`
+	Database       types.String `tfsdk:"database"`
+	Uri            types.String `tfsdk:"uri"`
+	Encryption     types.Bool   `tfsdk:"encryption"`
+	DirectHostOnly types.Bool   `tfsdk:"direct_host_only"`
 }
 
 //go:embed doc.md
@@ -34,7 +38,19 @@ func (r ResourceMongoDB) Schema(_ context.Context, req resource.SchemaRequest, r
 			"user":     schema.StringAttribute{Computed: true, MarkdownDescription: "Login username"},
 			"password": schema.StringAttribute{Computed: true, MarkdownDescription: "Login password", Sensitive: true},
 			"database": schema.StringAttribute{Computed: true, MarkdownDescription: "Database name"},
-			"uri":      schema.StringAttribute{Computed: true, MarkdownDescription: "Database connection string", Sensitive: true},
+			"uri": schema.StringAttribute{Computed: true, MarkdownDescription: "Database connection string", Sensitive: true},
+			"encryption": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Encrypt the hard drive at rest",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"direct_host_only": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
 		}),
 	}
 }

--- a/pkg/resources/database/mysql/crud.go
+++ b/pkg/resources/database/mysql/crud.go
@@ -81,8 +81,19 @@ func (r *ResourceMySQL) Create(ctx context.Context, req resource.CreateRequest, 
 
 	addonReq.Options["do-backup"] = "true"
 	if !my.Backup.IsNull() && !my.Backup.IsUnknown() {
-		backupValue := fmt.Sprintf("%t", my.Backup.ValueBool())
-		addonReq.Options["do-backup"] = backupValue
+		addonReq.Options["do-backup"] = fmt.Sprintf("%t", my.Backup.ValueBool())
+	}
+
+	if !my.Encryption.IsNull() && !my.Encryption.IsUnknown() {
+		addonReq.Options["encryption"] = fmt.Sprintf("%t", my.Encryption.ValueBool())
+	}
+
+	if !my.DirectHostOnly.IsNull() && !my.DirectHostOnly.IsUnknown() {
+		addonReq.Options["direct-host-only"] = fmt.Sprintf("%t", my.DirectHostOnly.ValueBool())
+	}
+
+	if !my.SkipLogBin.IsNull() && !my.SkipLogBin.IsUnknown() {
+		addonReq.Options["skip-log-bin"] = fmt.Sprintf("%t", my.SkipLogBin.ValueBool())
 	}
 
 	res := tmp.CreateAddon(ctx, r.Client(), r.Organization(), addonReq)
@@ -116,6 +127,28 @@ func (r *ResourceMySQL) Create(ctx context.Context, req resource.CreateRequest, 
 	my.Version = pkg.FromStr(addonMy.Version)
 	my.Uri = pkg.FromStr(addonMy.Uri())
 	my.ReadOnlyUsers = tmp.FromMySQLReadOnlyUsers(addonMy.ReadOnlyUsers)
+
+	if my.Encryption.IsUnknown() {
+		my.Encryption = pkg.FromBool(false)
+	}
+	if my.DirectHostOnly.IsUnknown() {
+		my.DirectHostOnly = pkg.FromBool(false)
+	}
+	if my.SkipLogBin.IsUnknown() {
+		my.SkipLogBin = pkg.FromBool(false)
+	}
+	for _, feature := range addonMy.Features {
+		switch feature.Name {
+		case "do-backup":
+			my.Backup = pkg.FromBool(feature.Enabled)
+		case "encryption":
+			my.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			my.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		case "skip-log-bin":
+			my.SkipLogBin = pkg.FromBool(feature.Enabled)
+		}
+	}
 
 	addon.SyncNetworkGroups(
 		ctx,
@@ -196,8 +229,15 @@ func (r *ResourceMySQL) Read(ctx context.Context, req resource.ReadRequest, resp
 	my.ReadOnlyUsers = tmp.FromMySQLReadOnlyUsers(addonMy.ReadOnlyUsers)
 
 	for _, feature := range addonMy.Features {
-		if feature.Name == "do-backup" {
+		switch feature.Name {
+		case "do-backup":
 			my.Backup = pkg.FromBool(feature.Enabled)
+		case "encryption":
+			my.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			my.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		case "skip-log-bin":
+			my.SkipLogBin = pkg.FromBool(feature.Enabled)
 		}
 	}
 

--- a/pkg/resources/database/mysql/schema.go
+++ b/pkg/resources/database/mysql/schema.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.clever-cloud.com/terraform-provider/pkg"
@@ -28,6 +30,9 @@ type MySQL struct {
 	Uri      types.String `tfsdk:"uri"`
 
 	Backup        types.Bool `tfsdk:"backup"`
+	Encryption    types.Bool `tfsdk:"encryption"`
+	DirectHostOnly types.Bool `tfsdk:"direct_host_only"`
+	SkipLogBin    types.Bool `tfsdk:"skip_log_bin"`
 	ReadOnlyUsers types.List `tfsdk:"read_only_users"`
 }
 
@@ -58,6 +63,25 @@ func (r ResourceMySQL) Schema(_ context.Context, req resource.SchemaRequest, res
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
 				MarkdownDescription: "Enable or disable backups for this MySQL add-on. Since backups are included in the add-on price, disabling it has no impact on your billing.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"encryption": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Encrypt the hard drive at rest",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"direct_host_only": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"skip_log_bin": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Disable binary logging. Saves disk space but prevents point-in-time recovery and replication.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
 			"read_only_users": schema.ListNestedAttribute{
 				Optional:            true,

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -81,10 +81,17 @@ func (r *ResourcePostgreSQL) Create(ctx context.Context, req resource.CreateRequ
 		addonReq.Options["do-backup"] = "true"
 	}
 
-	pkg.IfIsSetB(pg.Encryption, func(s bool) {
-		backupValue := fmt.Sprintf("%t", pg.Backup.ValueBool())
-		addonReq.Options["encryption"] = backupValue
-	})
+	if !pg.Encryption.IsNull() && !pg.Encryption.IsUnknown() {
+		addonReq.Options["encryption"] = fmt.Sprintf("%t", pg.Encryption.ValueBool())
+	}
+
+	if !pg.DirectHostOnly.IsNull() && !pg.DirectHostOnly.IsUnknown() {
+		addonReq.Options["direct-host-only"] = fmt.Sprintf("%t", pg.DirectHostOnly.ValueBool())
+	}
+
+	if !pg.Locale.IsNull() && !pg.Locale.IsUnknown() {
+		addonReq.Options["locale"] = fmt.Sprintf("%t", pg.Locale.ValueBool())
+	}
 
 	res := tmp.CreateAddon(ctx, r.Client(), r.Organization(), addonReq)
 	if res.HasError() {
@@ -117,10 +124,23 @@ func (r *ResourcePostgreSQL) Create(ctx context.Context, req resource.CreateRequ
 	pg.Version = pkg.FromStr(addonPG.Version)
 	pg.Uri = pkg.FromStr(addonPG.Uri())
 
+	if pg.Encryption.IsUnknown() {
+		pg.Encryption = pkg.FromBool(false)
+	}
+	if pg.DirectHostOnly.IsUnknown() {
+		pg.DirectHostOnly = pkg.FromBool(false)
+	}
+	if pg.Locale.IsUnknown() {
+		pg.Locale = pkg.FromBool(false)
+	}
 	for _, option := range addonPG.Features {
 		switch option.Name {
 		case "encryption":
 			pg.Encryption = pkg.FromBool(option.Enabled)
+		case "direct-host-only":
+			pg.DirectHostOnly = pkg.FromBool(option.Enabled)
+		case "locale":
+			pg.Locale = pkg.FromBool(option.Enabled)
 		}
 	}
 
@@ -200,6 +220,10 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 				pg.Backup = pkg.FromBool(feature.Enabled)
 			case "encryption":
 				pg.Encryption = pkg.FromBool(feature.Enabled)
+			case "direct-host-only":
+				pg.DirectHostOnly = pkg.FromBool(feature.Enabled)
+			case "locale":
+				pg.Locale = pkg.FromBool(feature.Enabled)
 			}
 		}
 	}

--- a/pkg/resources/database/postgresql/schema.go
+++ b/pkg/resources/database/postgresql/schema.go
@@ -29,8 +29,10 @@ type PostgreSQL struct {
 	Version  types.String `tfsdk:"version"`
 	Uri      types.String `tfsdk:"uri"`
 
-	Backup     types.Bool `tfsdk:"backup"`
-	Encryption types.Bool `tfsdk:"encryption"`
+	Backup         types.Bool `tfsdk:"backup"`
+	Encryption     types.Bool `tfsdk:"encryption"`
+	DirectHostOnly types.Bool `tfsdk:"direct_host_only"`
+	Locale         types.Bool `tfsdk:"locale"`
 }
 
 //go:embed doc.md
@@ -66,6 +68,18 @@ func (r ResourcePostgreSQL) Schema(_ context.Context, req resource.SchemaRequest
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Encrypt the hard drive at rest",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"direct_host_only": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"locale": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Enable locale support for collation and character classification",
 				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
 		}),

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -276,12 +276,18 @@ func GetMetabase(ctx context.Context, cc *client.Client, metabaseID string) clie
 }
 
 type MongoDB struct {
-	Host     string `json:"host"`
-	Port     int64  `json:"port"`
-	Status   string `json:"status" example:"ACTIVE"`
-	User     string `tfsdk:"user"`
-	Password string `tfsdk:"password"`
-	Database string `tfsdk:"database"`
+	Host     string           `json:"host"`
+	Port     int64            `json:"port"`
+	Status   string           `json:"status" example:"ACTIVE"`
+	User     string           `json:"user"`
+	Password string           `json:"password"`
+	Database string           `json:"database"`
+	Features []MongoDBFeature `json:"features"`
+}
+
+type MongoDBFeature struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
 }
 
 func (mg MongoDB) Uri() string {


### PR DESCRIPTION
## Summary

- **MySQL**: add `encryption`, `direct_host_only`, `skip_log_bin` feature flags, add `RequiresReplace` on `backup`
- **PostgreSQL**: add `direct_host_only`, `locale` feature flags
- **MongoDB**: add `encryption`, `direct_host_only` feature flags, add `MongoDBFeature` API struct

### Bug fixes

- PostgreSQL `encryption` option was sending the backup value (copy-paste in `IfIsSetB` callback). Replaced with explicit checks.
- MongoDB API struct had `tfsdk` tags instead of `json`, causing empty fields on deserialization.
- MySQL `backup` was missing `RequiresReplace` (features are immutable after creation).