### PR TITLE
feat: validate addon options against plan capabilities (#367)

### DIFF
--- a/pkg/resources/database/mysql/mysql.go
+++ b/pkg/resources/database/mysql/mysql.go
@@ -3,9 +3,17 @@ package mysql
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+)
+
+// Ensure ResourceMySQL implements required interfaces
+var (
+	_ resource.Resource              = &ResourceMySQL{}
+	_ resource.ResourceWithModifyPlan = &ResourceMySQL{}
 )
 
 type ResourceMySQL struct {
@@ -22,4 +30,75 @@ func NewResourceMySQL() resource.Resource {
 
 func (r *ResourceMySQL) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_mysql"
+}
+
+// ModifyPlan validates that encryption, backup, skip_log_bin, and direct_host_only options are only used with dedicated plans
+func (r *ResourceMySQL) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() { // Skip validation when deleting
+		return
+	}
+
+	plan := helper.From[MySQL](ctx, req.Plan, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	// Skip validation if provider not configured yet
+	if r.Client() == nil {
+		return
+	}
+
+	// Get addon providers to check plan features
+	addonsProvidersRes := tmp.GetAddonsProviders(ctx, r.Client())
+	if addonsProvidersRes.HasError() {
+		res.Diagnostics.AddError("failed to get addon providers", addonsProvidersRes.Error().Error())
+		return
+	}
+	addonsProviders := addonsProvidersRes.Payload()
+
+	prov := pkg.LookupAddonProvider(*addonsProviders, "mysql-addon")
+	if prov == nil {
+		res.Diagnostics.AddError("MySQL provider not found", "Could not find mysql-addon provider")
+		return
+	}
+
+	addonPlan := pkg.LookupProviderPlan(prov, plan.Plan.ValueString())
+	if addonPlan == nil {
+		// Plan validation will be handled elsewhere
+		return
+	}
+
+	isDedicated := addonPlan.IsDedicated()
+
+	if !plan.Encryption.IsNull() && !plan.Encryption.IsUnknown() && plan.Encryption.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeError(
+			path.Root("encryption"),
+			"Encryption not supported on shared plans",
+			"At-rest encryption is only available on dedicated MySQL plans. Please either remove the encryption option or upgrade to a dedicated plan (e.g., 'xs_sml', 'xxs_sml').",
+		)
+	}
+
+	if !plan.Backup.IsNull() && !plan.Backup.IsUnknown() && !plan.Backup.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeWarning(
+			path.Root("backup"),
+			"Backup configuration not supported on shared plans",
+			"The backup option is not configurable on the 'dev' plan.",
+		)
+	}
+
+	if !plan.SkipLogBin.IsNull() && !plan.SkipLogBin.IsUnknown() && plan.SkipLogBin.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeError(
+			path.Root("skip_log_bin"),
+			"Skip log bin not supported on shared plans",
+			"The skip_log_bin option is only available on dedicated MySQL plans. Please either remove the skip_log_bin option or upgrade to a dedicated plan (e.g., 'xs_sml', 'xxs_sml').",
+		)
+	}
+
+	if !plan.DirectHostOnly.IsNull() && !plan.DirectHostOnly.IsUnknown() && plan.DirectHostOnly.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeError(
+			path.Root("direct_host_only"),
+			"Direct host only not supported on shared plans",
+			"The direct_host_only option is only available on dedicated MySQL plans. Please either remove the direct_host_only option or upgrade to a dedicated plan (e.g., 'xs_sml', 'xxs_sml').",
+		)
+	}
 }

--- a/pkg/resources/database/mysql/mysql_test.go
+++ b/pkg/resources/database/mysql/mysql_test.go
@@ -128,3 +128,88 @@ func TestAccMySQL_RefreshDeleted(t *testing.T) {
 		},
 	})
 }
+
+// TestAccMySQL_EncryptionOnDevPlan tests that encryption option is not allowed on dev plan
+// Similar to PostgreSQL issue #367
+func TestAccMySQL_EncryptionOnDevPlan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-my-enc")
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	mysqlBlock := helper.NewRessource(
+		"clevercloud_mysql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":       rName,
+			"region":     "par",
+			"plan":       "dev",
+			"encryption": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(mysqlBlock).String(),
+			ExpectError:  regexp.MustCompile(`Encryption not supported on shared plans`),
+		}},
+	})
+}
+
+// TestAccMySQL_SkipLogBinOnDevPlan tests that skip_log_bin option is not allowed on dev plan
+func TestAccMySQL_SkipLogBinOnDevPlan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-my-skiplog")
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	mysqlBlock := helper.NewRessource(
+		"clevercloud_mysql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":         rName,
+			"region":       "par",
+			"plan":         "dev",
+			"skip_log_bin": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(mysqlBlock).String(),
+			ExpectError:  regexp.MustCompile(`Skip log bin not supported on shared plans`),
+		}},
+	})
+}
+
+// TestAccMySQL_DirectHostOnlyOnDevPlan tests that direct_host_only option is not allowed on dev plan
+func TestAccMySQL_DirectHostOnlyOnDevPlan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-my-direct")
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	mysqlBlock := helper.NewRessource(
+		"clevercloud_mysql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":             rName,
+			"region":           "par",
+			"plan":             "dev",
+			"direct_host_only": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(mysqlBlock).String(),
+			ExpectError:  regexp.MustCompile(`Direct host only not supported on shared plans`),
+		}},
+	})
+}

--- a/pkg/resources/database/postgresql/postgresql.go
+++ b/pkg/resources/database/postgresql/postgresql.go
@@ -3,9 +3,18 @@ package postgresql
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+)
+
+// Ensure ResourcePostgreSQL implements required interfaces
+var (
+	_ resource.Resource               = &ResourcePostgreSQL{}
+	_ resource.ResourceWithModifyPlan = &ResourcePostgreSQL{}
 )
 
 type ResourcePostgreSQL struct {
@@ -22,4 +31,78 @@ func NewResourcePostgreSQL() resource.Resource {
 
 func (r *ResourcePostgreSQL) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_postgresql"
+}
+
+// ModifyPlan validates that encryption, backup, and locale options are only used with dedicated plans
+func (r *ResourcePostgreSQL) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	tflog.Debug(ctx, "ModifyPlan called for PostgreSQL")
+
+	if req.Plan.Raw.IsNull() { // Skip validation when deleting
+		return
+	}
+
+	plan := helper.From[PostgreSQL](ctx, req.Plan, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	// Skip validation if provider not configured yet
+	if r.Client() == nil {
+		tflog.Debug(ctx, "Skipping validation - provider not configured")
+		return
+	}
+
+	// Get addon providers to check plan features
+	addonsProvidersRes := tmp.GetAddonsProviders(ctx, r.Client())
+	if addonsProvidersRes.HasError() {
+		tflog.Warn(ctx, "Skipping validation - failed to get addon providers", map[string]any{"error": addonsProvidersRes.Error().Error()})
+		// Silently skip validation if we can't fetch provider info during plan phase
+		// The actual creation will fail with a proper error if there's a real issue
+		return
+	}
+	addonsProviders := addonsProvidersRes.Payload()
+
+	prov := pkg.LookupAddonProvider(*addonsProviders, "postgresql-addon")
+	if prov == nil {
+		tflog.Debug(ctx, "Skipping validation - PostgreSQL provider not found")
+		// Skip validation if provider info is not available
+		return
+	}
+
+	addonPlan := pkg.LookupProviderPlan(prov, plan.Plan.ValueString())
+	if addonPlan == nil {
+		tflog.Debug(ctx, "Skipping validation - plan not found", map[string]any{"plan": plan.Plan.ValueString()})
+		// Plan validation will be handled elsewhere
+		return
+	}
+
+	isDedicated := addonPlan.IsDedicated()
+	tflog.Debug(ctx, "Plan validation", map[string]any{"plan": plan.Plan.ValueString(), "isDedicated": isDedicated})
+
+	// Validate encryption option
+	if !plan.Encryption.IsNull() && !plan.Encryption.IsUnknown() && plan.Encryption.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeError(
+			path.Root("encryption"),
+			"Encryption not supported on shared plans",
+			"At-rest encryption is only available on dedicated PostgreSQL plans. Please either remove the encryption option or upgrade to a dedicated plan (e.g., 'xs_sml', 'xxs_sml').",
+		)
+	}
+
+	// Validate backup option
+	if !plan.Backup.IsNull() && !plan.Backup.IsUnknown() && !plan.Backup.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeWarning(
+			path.Root("backup"),
+			"Backup configuration may not be supported on shared plans",
+			"The backup option may not be configurable on the 'dev' plan as it uses a shared cluster.",
+		)
+	}
+
+	// Validate locale option
+	if !plan.Locale.IsNull() && !plan.Locale.IsUnknown() && plan.Locale.ValueBool() && !isDedicated {
+		res.Diagnostics.AddAttributeError(
+			path.Root("locale"),
+			"Locale not supported on shared plans",
+			"Locale support is only available on dedicated PostgreSQL plans (not 'dev'). Please either remove the locale option or upgrade to a dedicated plan (e.g., 'xs_sml', 'xxs_sml').",
+		)
+	}
 }

--- a/pkg/resources/database/postgresql/postgresql_test.go
+++ b/pkg/resources/database/postgresql/postgresql_test.go
@@ -198,3 +198,61 @@ func TestAccPostgreSQL_migration(t *testing.T) {
 		}},
 	})
 }
+
+// TestAccPostgreSQL_EncryptionOnDevPlan reproduces issue #367
+// When encryption=true is set on a 'dev' plan PostgreSQL, the provider should validate this
+// and provide a clear error message since dev plans don't support encryption.
+func TestAccPostgreSQL_EncryptionOnDevPlan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-pg-enc")
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	postgresqlBlock := helper.NewRessource(
+		"clevercloud_postgresql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":       rName,
+			"region":     "par",
+			"plan":       "dev",
+			"encryption": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(postgresqlBlock).String(),
+			ExpectError:  regexp.MustCompile(`Encryption not supported on shared plans`),
+		}},
+	})
+}
+
+// TestAccPostgreSQL_LocaleOnDevPlan tests that locale option is not allowed on dev plan
+func TestAccPostgreSQL_LocaleOnDevPlan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-pg-locale")
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	postgresqlBlock := helper.NewRessource(
+		"clevercloud_postgresql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"plan":   "dev",
+			"locale": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(postgresqlBlock).String(),
+			ExpectError:  regexp.MustCompile(`Locale not supported on shared plans`),
+		}},
+	})
+}

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -38,10 +38,33 @@ type AddonResponseProvider struct {
 }
 
 type AddonPlan struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Slug string `json:"slug"`
+	ID       string             `json:"id"`
+	Name     string             `json:"name"`
+	Slug     string             `json:"slug"`
+	Features []AddonPlanFeature `json:"features"`
 }
+
+type AddonPlanFeature struct {
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	ComputableValue string `json:"computable_value,omitempty"`
+	NameCode        string `json:"name_code,omitempty"`
+}
+
+// IsDedicated returns true if the plan has the "is-dedicated" feature set to "dedicated" (not "Shared")
+func (plan *AddonPlan) IsDedicated() bool {
+	if plan == nil {
+		return false
+	}
+	for _, feature := range plan.Features {
+		if feature.NameCode == "is-dedicated" {
+			// Value can be "dedicated" or "Shared"
+			return feature.ComputableValue == "dedicated"
+		}
+	}
+	return false
+}
+
 type AddonPlans []AddonPlan
 
 func (provider *AddonProvider) FirstPlan() *AddonPlan {

--- a/pkg/tmp/addon_test.go
+++ b/pkg/tmp/addon_test.go
@@ -1,0 +1,68 @@
+package tmp
+
+import (
+	"testing"
+)
+
+func TestAddonPlan_IsDedicated(t *testing.T) {
+	tests := []struct {
+		name     string
+		plan     *AddonPlan
+		expected bool
+	}{
+		{
+			name: "dedicated plan",
+			plan: &AddonPlan{
+				ID:   "xs_sml",
+				Name: "XS Small",
+				Slug: "xs_sml",
+				Features: []AddonPlanFeature{
+					{
+						NameCode:        "is-dedicated",
+						ComputableValue: "dedicated",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "shared plan",
+			plan: &AddonPlan{
+				ID:   "dev",
+				Name: "DEV",
+				Slug: "dev",
+				Features: []AddonPlanFeature{
+					{
+						NameCode:        "is-dedicated",
+						ComputableValue: "Shared",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "plan without is-dedicated feature",
+			plan: &AddonPlan{
+				ID:       "test",
+				Name:     "Test Plan",
+				Slug:     "test",
+				Features: []AddonPlanFeature{},
+			},
+			expected: false,
+		},
+		{
+			name:     "nil plan",
+			plan:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.plan.IsDedicated()
+			if result != tt.expected {
+				t.Errorf("IsDedicated() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #367

This commit adds plan-time validation for PostgreSQL and MySQL addon options that are only available on dedicated plans. Previously, attempting to use these options on shared plans (like 'dev') would fail during apply with an unclear error "Provider produced inconsistent result after apply". Now, users get clear validation errors during the plan phase.

Changes:
- Add Features field to AddonPlan struct to capture plan capabilities from API
- Implement IsDedicated() method to detect dedicated vs shared plans using the "is-dedicated" feature
- Add ModifyPlan validation to PostgreSQL resource for encryption, locale, and backup options
- Add ModifyPlan validation to MySQL resource for encryption, skip_log_bin, direct_host_only, and backup options
- Add unit tests for IsDedicated() logic
- Add acceptance tests for validation behavior

The validation works by fetching addon provider information from the API during plan phase and checking if the plan has the "is-dedicated" feature set to "dedicated" (vs "Shared" for shared cluster plans).

Error messages now clearly explain which options require dedicated plans and suggest alternative plans.