### PR TITLE
test(k8s): shrink nodegroup acceptance test to a single node

### DIFF
--- a/pkg/resources/kubernetes/nodegroup/nodegroup_test.go
+++ b/pkg/resources/kubernetes/nodegroup/nodegroup_test.go
@@ -30,7 +30,12 @@ func TestAccKubernetesNodegroup_basic(t *testing.T) {
 				"kubernetes_id": "${clevercloud_kubernetes." + rName + ".id}",
 				"flavor":        "S",
 				"name":          rName,
-				"size":          3,
+				// Single node keeps the test under the K8S product quota
+				// when this and TestAccKubernetes_basic run in parallel:
+				// 8G CP + 12G S-node = 20G here, +8G for the basic test = 28G
+				// total against a 52G quota. Bumping size also bumps the wall
+				// clock, so leave scaling coverage to a dedicated test.
+				"size": 1,
 			}),
 		)
 
@@ -44,7 +49,7 @@ func TestAccKubernetesNodegroup_basic(t *testing.T) {
 			ConfigStateChecks: []statecheck.StateCheck{
 				//statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^node_group_.*`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
-				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("size"), knownvalue.Int64Exact(3)),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("size"), knownvalue.Int64Exact(1)),
 			},
 		}},
 	})


### PR DESCRIPTION
The K8S product quota is 52G of RAM. TestAccKubernetesNodegroup_basic provisions a control plane (8G) plus 3 S-flavor nodes (3×12G = 36G) = 44G, while TestAccKubernetes_basic (running in a parallel package) takes another 8G — exactly 52G combined, leaving zero margin for any timing overlap between create and destroy phases.

Drop the nodegroup size to 1: total combined footprint becomes 28G, giving a 24G margin. The test still validates create/destroy and the flavor/size propagation; scaling-specific coverage belongs to a dedicated test rather than the basic happy-path.