### PR TITLE
refactor(keycloak): migrate GetKeycloak to addon-providers endpoint

### DIFF
--- a/pkg/resources/software/keycloak/crud.go
+++ b/pkg/resources/software/keycloak/crud.go
@@ -59,12 +59,11 @@ func (r *ResourceKeycloak) Create(ctx context.Context, req resource.CreateReques
 
 	keycloakRes := r.SDK.
 		V4().
-		Keycloaks().
-		Organisations().
-		Ownerid(r.Organization()).
-		Keycloaks().
+		AddonProviders().
+		AddonKeycloak().
+		Addons().
 		Addonkeycloakid(addon.RealID).
-		Getkeycloak(ctx)
+		Getkeycloakwithoutownerid(ctx)
 	if keycloakRes.HasError() {
 		res.Diagnostics.AddError("failed to get Keycloak", keycloakRes.Error().Error())
 	} else {
@@ -107,12 +106,11 @@ func (r *ResourceKeycloak) Read(ctx context.Context, req resource.ReadRequest, r
 
 	keycloakRes := r.SDK.
 		V4().
-		Keycloaks().
-		Organisations().
-		Ownerid(r.Organization()).
-		Keycloaks().
+		AddonProviders().
+		AddonKeycloak().
+		Addons().
 		Addonkeycloakid(state.ID.ValueString()).
-		Getkeycloak(ctx)
+		Getkeycloakwithoutownerid(ctx)
 	if keycloakRes.IsNotFoundError() {
 		resp.State.RemoveResource(ctx)
 		return


### PR DESCRIPTION
Switch the Create and Read paths from
  /v4/keycloaks/organisations/{ownerId}/keycloaks/{id}
to
  /v4/addon-providers/addon-keycloak/addons/{id}

The new endpoint derives the owner from the addon ID, so the call site no longer has to plumb the organization through. Same response shape (models.Keycloak), so all the field mappings stay identical.

Update (Createversionupdatekeycloak) is unchanged — it already lives under /v4/addon-providers/addon-keycloak/addons.