### PR TITLE
fix(mysql): populate feature defaults in Read to prevent force-replac…

### DIFF
--- a/pkg/resources/database/mysql/crud.go
+++ b/pkg/resources/database/mysql/crud.go
@@ -104,8 +104,7 @@ func (r *ResourceMySQL) Create(ctx context.Context, req resource.CreateRequest, 
 	createdMy := res.Payload()
 
 	my.ID = pkg.FromStr(createdMy.RealID)
-	my.CreationDate = pkg.FromI(createdMy.CreationDate)
-	my.Plan = pkg.FromStr(createdMy.Plan.Slug)
+	r.readFromAddon(&my, *createdMy)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, my)...)
 
@@ -113,41 +112,8 @@ func (r *ResourceMySQL) Create(ctx context.Context, req resource.CreateRequest, 
 	if myInfoRes.HasError() {
 		resp.Diagnostics.AddError("failed to get mysql connection infos", myInfoRes.Error().Error())
 		return
-	}
-	addonMy := myInfoRes.Payload()
-
-	tflog.Debug(ctx, "API response", map[string]any{
-		"payload": fmt.Sprintf("%+v", addonMy),
-	})
-	my.Host = pkg.FromStr(addonMy.Host)
-	my.Port = pkg.FromI(int64(addonMy.Port))
-	my.Database = pkg.FromStr(addonMy.Database)
-	my.User = pkg.FromStr(addonMy.User)
-	my.Password = pkg.FromStr(addonMy.Password)
-	my.Version = pkg.FromStr(addonMy.Version)
-	my.Uri = pkg.FromStr(addonMy.Uri())
-	my.ReadOnlyUsers = tmp.FromMySQLReadOnlyUsers(addonMy.ReadOnlyUsers)
-
-	if my.Encryption.IsUnknown() {
-		my.Encryption = pkg.FromBool(false)
-	}
-	if my.DirectHostOnly.IsUnknown() {
-		my.DirectHostOnly = pkg.FromBool(false)
-	}
-	if my.SkipLogBin.IsUnknown() {
-		my.SkipLogBin = pkg.FromBool(false)
-	}
-	for _, feature := range addonMy.Features {
-		switch feature.Name {
-		case "do-backup":
-			my.Backup = pkg.FromBool(feature.Enabled)
-		case "encryption":
-			my.Encryption = pkg.FromBool(feature.Enabled)
-		case "direct-host-only":
-			my.DirectHostOnly = pkg.FromBool(feature.Enabled)
-		case "skip-log-bin":
-			my.SkipLogBin = pkg.FromBool(feature.Enabled)
-		}
+	} else {
+		r.readFromAPI(&my, *myInfoRes.Payload())
 	}
 
 	addon.SyncNetworkGroups(
@@ -193,8 +159,10 @@ func (r *ResourceMySQL) Read(ctx context.Context, req resource.ReadRequest, resp
 	if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Mysql resource", addonRes.Error().Error())
 		return
+	} else {
+		addonInfo := addonRes.Payload()
+		r.readFromAddon(&my, *addonInfo)
 	}
-	addonInfo := addonRes.Payload()
 
 	addonMyRes := tmp.GetMySQL(ctx, r.Client(), addonId)
 	if addonMyRes.IsNotFoundError() {
@@ -204,47 +172,56 @@ func (r *ResourceMySQL) Read(ctx context.Context, req resource.ReadRequest, resp
 	if addonMyRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Mysql resource", addonMyRes.Error().Error())
 		return
-	}
-
-	addonMy := addonMyRes.Payload()
-
-	if addonMy.Status == "TO_DELETE" {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	tflog.Debug(ctx, "STATE", map[string]any{"my": my})
-	tflog.Debug(ctx, "API", map[string]any{"my": addonMy})
-	my.ID = pkg.FromStr(addonInfo.RealID)
-	my.Name = pkg.FromStr(addonInfo.Name)
-	my.Plan = pkg.FromStr(addonMy.Plan)
-	my.Region = pkg.FromStr(addonMy.Zone)
-	my.CreationDate = pkg.FromI(addonInfo.CreationDate)
-	my.Host = pkg.FromStr(addonMy.Host)
-	my.Port = pkg.FromI(int64(addonMy.Port))
-	my.Database = pkg.FromStr(addonMy.Database)
-	my.User = pkg.FromStr(addonMy.User)
-	my.Password = pkg.FromStr(addonMy.Password)
-	my.Version = pkg.FromStr(addonMy.Version)
-	my.Uri = pkg.FromStr(addonMy.Uri())
-	my.ReadOnlyUsers = tmp.FromMySQLReadOnlyUsers(addonMy.ReadOnlyUsers)
-
-	for _, feature := range addonMy.Features {
-		switch feature.Name {
-		case "do-backup":
-			my.Backup = pkg.FromBool(feature.Enabled)
-		case "encryption":
-			my.Encryption = pkg.FromBool(feature.Enabled)
-		case "direct-host-only":
-			my.DirectHostOnly = pkg.FromBool(feature.Enabled)
-		case "skip-log-bin":
-			my.SkipLogBin = pkg.FromBool(feature.Enabled)
+	} else {
+		addonMy := addonMyRes.Payload()
+		if addonMy.Status == "TO_DELETE" {
+			resp.State.RemoveResource(ctx)
+			return
 		}
+
+		r.readFromAPI(&my, *addonMy)
 	}
 
 	my.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonId, &resp.Diagnostics)
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, my)...)
+}
+
+func (r *ResourceMySQL) readFromAddon(state *MySQL, addon tmp.AddonResponse) {
+	state.Name = pkg.FromStr(addon.Name)
+	state.Plan = pkg.FromStr(addon.Plan.Slug)
+	state.Region = pkg.FromStr(addon.Region)
+	state.CreationDate = pkg.FromI(addon.CreationDate)
+}
+
+func (r *ResourceMySQL) readFromAPI(state *MySQL, my tmp.MySQL) {
+	state.Host = pkg.FromStr(my.Host)
+	state.Port = pkg.FromI(int64(my.Port))
+	state.Database = pkg.FromStr(my.Database)
+	state.User = pkg.FromStr(my.User)
+	state.Password = pkg.FromStr(my.Password)
+	state.Version = pkg.FromStr(my.Version)
+	state.Uri = pkg.FromStr(my.Uri())
+	state.ReadOnlyUsers = tmp.FromMySQLReadOnlyUsers(my.ReadOnlyUsers)
+
+	// Initialize to defaults so attributes are never null in state after import.
+	// The features loop below overrides with actual API values if present.
+	state.Backup = pkg.FromBool(true)
+	state.Encryption = pkg.FromBool(false)
+	state.DirectHostOnly = pkg.FromBool(false)
+	state.SkipLogBin = pkg.FromBool(false)
+
+	for _, feature := range my.Features {
+		switch feature.Name {
+		case "do-backup":
+			state.Backup = pkg.FromBool(feature.Enabled)
+		case "encryption":
+			state.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			state.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		case "skip-log-bin":
+			state.SkipLogBin = pkg.FromBool(feature.Enabled)
+		}
+	}
 }
 
 // Update resource

--- a/pkg/resources/database/mysql/mysql_test.go
+++ b/pkg/resources/database/mysql/mysql_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tests"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
@@ -211,5 +213,91 @@ func TestAccMySQL_DirectHostOnlyOnDevPlan(t *testing.T) {
 			Config:       providerBlock.Append(mysqlBlock).String(),
 			ExpectError:  regexp.MustCompile(`Direct host only not supported on shared plans`),
 		}},
+	})
+}
+
+// TestAccMySQL_Import tests that importing a MySQL addon doesn't trigger
+// a force-replace on the next plan.
+// Reproduces GitHub issue #399: backup and skip_log_bin remain null in state
+// after import because Read doesn't populate them when the API omits features.
+// The null→default diff triggers RequiresReplace.
+func TestAccMySQL_Import(t *testing.T) {
+	t.Parallel()
+	cc := client.New(client.WithAutoOauthConfig())
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-my-import")
+	fullName := fmt.Sprintf("clevercloud_mysql.%s", rName)
+
+	var addonID string
+	var realID string
+
+	// Cleanup addon created via API in case the import step fails
+	// before Terraform takes ownership of the resource.
+	t.Cleanup(func() {
+		if addonID != "" {
+			tmp.DeleteAddon(context.Background(), cc, tests.ORGANISATION, addonID)
+		}
+	})
+
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	mysqlBlock := helper.NewRessource(
+		"clevercloud_mysql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"plan":   "xs_sml",
+			"backup": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// Create MySQL addon manually via API to simulate a pre-existing
+				// resource, then import it into Terraform state.
+				PreConfig: func() {
+					addonsProvidersRes := tmp.GetAddonsProviders(ctx, cc)
+					if addonsProvidersRes.HasError() {
+						t.Fatalf("failed to get addon providers: %s", addonsProvidersRes.Error())
+					}
+					prov := pkg.LookupAddonProvider(*addonsProvidersRes.Payload(), "mysql-addon")
+					plan := pkg.LookupProviderPlan(prov, "xs_sml")
+					if plan == nil {
+						t.Fatal("failed to find xs_sml plan for mysql-addon")
+					}
+
+					res := tmp.CreateAddon(ctx, cc, tests.ORGANISATION, tmp.AddonRequest{
+						Name:       rName,
+						Plan:       plan.ID,
+						ProviderID: "mysql-addon",
+						Region:     "par",
+						Options:    map[string]string{"do-backup": "true"},
+					})
+					if res.HasError() {
+						t.Fatalf("failed to create mysql addon: %s", res.Error())
+					}
+					addonID = res.Payload().ID
+					realID = res.Payload().RealID
+				},
+				Config:       providerBlock.Append(mysqlBlock).String(),
+				ResourceName: fullName,
+				ImportState:  true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
+					return realID, nil
+				},
+			},
+			{
+				// Re-apply the same config after import.
+				// If backup/skip_log_bin are null in state (the bug), the schema
+				// defaults will create a diff and RequiresReplace will trigger
+				// a force-replace plan, causing this step to fail.
+				Config:   providerBlock.Append(mysqlBlock).String(),
+				PlanOnly: true,
+			},
+		},
 	})
 }


### PR DESCRIPTION
…e on import (#399)

Extract readFromAddon/readFromAPI methods (à la Elasticsearch) so Create and Read share the same state-population logic.  readFromAPI now initialises backup, encryption, direct_host_only and skip_log_bin to their schema defaults *before* iterating over API features, ensuring attributes are never left null in state after import.

Add TestAccMySQL_Import acceptance test that creates an addon via the API, imports it, then verifies the next plan is empty.