### PR TITLE
refactor(application): centralize Sync* calls in Create[T]/Update[T]

### DIFF
--- a/pkg/resources/application/create.go
+++ b/pkg/resources/application/create.go
@@ -165,6 +165,14 @@ func Create[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan T
 		runtime.SetFromResponse(createRes, ctx, &diags)
 	}
 
+	// Sync resources exposed through dedicated API endpoints, once the app exists
+	if !diags.HasError() && !runtime.ID.IsNull() && !runtime.ID.IsUnknown() {
+		appID := runtime.ID.ValueString()
+		SyncNetworkGroups(ctx, resource, appID, runtime.Networkgroups, &diags)
+		SyncExposedVariables(ctx, resource, appID, runtime.ExposedEnvironment, &diags)
+		SyncDependencies(ctx, resource, appID, runtime.Dependencies, &diags)
+	}
+
 	return diags
 }
 

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -75,18 +72,7 @@ func (r *ResourceDocker) Update(ctx context.Context, req resource.UpdateRequest,
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceDotnet) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceDotnet) Update(ctx context.Context, req resource.UpdateRequest,
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceFrankenPHP) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -77,18 +74,7 @@ func (r *ResourceFrankenPHP) Update(ctx context.Context, req resource.UpdateRequ
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceGo) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceGo) Update(ctx context.Context, req resource.UpdateRequest, res
 
 	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceJava) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceLinux) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceLinux) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceNodeJS) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceNodeJS) Update(ctx context.Context, req resource.UpdateRequest,
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -30,9 +30,6 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -75,18 +72,7 @@ func (r *ResourcePHP) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -30,9 +30,6 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourcePlay2) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -30,9 +30,6 @@ func (r *ResourcePython) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -75,18 +72,7 @@ func (r *ResourcePython) Update(ctx context.Context, req resource.UpdateRequest,
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceRuby) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceRuby) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceRust) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -75,18 +72,7 @@ func (r *ResourceRust) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceScala) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceStatic) Update(ctx context.Context, req resource.UpdateRequest,
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceStaticApache) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceStaticApache) Update(ctx context.Context, req resource.UpdateRe
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 

--- a/pkg/resources/application/update.go
+++ b/pkg/resources/application/update.go
@@ -159,5 +159,13 @@ func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, 
 		runtime.SetFromResponse(updatedApp, ctx, &diags)
 	}
 
+	// Sync resources exposed through dedicated API endpoints
+	if !diags.HasError() {
+		appID := runtime.ID.ValueString()
+		SyncNetworkGroups(ctx, resource, appID, runtime.Networkgroups, &diags)
+		SyncExposedVariables(ctx, resource, appID, runtime.ExposedEnvironment, &diags)
+		SyncDependencies(ctx, resource, appID, runtime.Dependencies, &diags)
+	}
+
 	return diags
 }

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -30,9 +30,6 @@ func (r *ResourceV) Create(ctx context.Context, req resource.CreateRequest, resp
 	}
 
 	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
 	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
@@ -78,18 +75,7 @@ func (r *ResourceV) Update(ctx context.Context, req resource.UpdateRequest, res 
 
 	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
 
-	// First save: persist changes even if there were partial errors
-	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	// Secondary operations
-	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &res.Diagnostics)
-	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &res.Diagnostics)
-	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &res.Diagnostics)
-
-	// Second save: persist secondary operations results
+	// Persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 


### PR DESCRIPTION
## Summary

Closes #370.

`SyncNetworkGroups`, `SyncExposedVariables` and `SyncDependencies` were
called identically in all 16 runtime `crud.go` files. They are now invoked
once from the generic `Create[T]` / `Update[T]` functions, like VHosts and
Environment already are.

- centralize the 3 `Sync*` calls into `Create[T]` / `Update[T]`, removing
  ~6 duplicated lines from each runtime `crud.go`
- remove the now-redundant second state save in each runtime `Update` — its
  secondary block held only the `Sync*` calls, and the calls do not mutate
  `plan`
- **no `RuntimePlan` interface change**: contrary to the issue's estimate,
  `Networkgroups` / `ExposedEnvironment` / `Dependencies` already live on the
  shared `Runtime` struct, reachable via the existing `GetRuntimePtr()`