### PR TITLE
fix(application): restart app when only env vars change

### DIFF
--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceDotnet) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceFrankenPHP) Create(ctx context.Context, req resource.CreateRequ
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/git.go
+++ b/pkg/resources/application/git.go
@@ -20,19 +20,27 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 )
 
-func GitDeploy(ctx context.Context, d *Deployment, cleverRemote string, diags *diag.Diagnostics) {
+// GitDeploy pushes the configured repository to the Clever Cloud remote.
+// deployedCommit is the commit currently deployed on the application (CommitID
+// from the API, empty when unknown or never deployed): when the resolved
+// target commit already matches it, the push is skipped.
+// It returns true only when a push actually triggered a deployment, so the
+// caller can decide whether an explicit restart is still needed (e.g. when
+// only environment variables changed).
+func GitDeploy(ctx context.Context, d *Deployment, cleverRemote, deployedCommit string, diags *diag.Diagnostics) bool {
 	var errs diag.Diagnostics
+	var deployed bool
 
 	if d == nil {
-		return
+		return false
 	}
 	if d.Commit != nil && strings.HasPrefix(*d.Commit, attributes.GITHUB_COMMIT_PREFIX) {
 		tflog.Warn(ctx, "repository deployment is handled by Github, skipping deployment")
-		return
+		return false
 	}
 
 	for range 5 {
-		errs = gitDeploy(ctx, *d, cleverRemote)
+		deployed, errs = gitDeploy(ctx, *d, cleverRemote, deployedCommit)
 		if !errs.HasError() {
 			break
 		}
@@ -42,20 +50,27 @@ func GitDeploy(ctx context.Context, d *Deployment, cleverRemote string, diags *d
 
 	// only add last error
 	diags.Append(errs...)
+	return deployed
 }
 
-func gitDeploy(ctx context.Context, d Deployment, cleverRemote string) diag.Diagnostics {
+func gitDeploy(ctx context.Context, d Deployment, cleverRemote, deployedCommit string) (bool, diag.Diagnostics) {
 	cleverRemote = strings.Replace(cleverRemote, "git+ssh", "https", 1) // switch protocol
 
 	repo, diags := OpenOrClone(ctx, d.Repository, WithCommit(d.Commit), WithBasicAuth(d.Username, d.Password))
 	if diags.HasError() {
-		return diags
+		return false, diags
 	}
 
-	currentRef, err := repo.Head()
-	if err != nil {
-		diags.AddError("failed to get current ref", err.Error())
-		return diags
+	targetCommit, diags := resolveTargetCommit(repo, d.Commit)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	if deployedCommit != "" && targetCommit == deployedCommit {
+		tflog.Info(ctx, "deployed commit is already the expected one, skipping git push", map[string]any{
+			"commit": targetCommit,
+		})
+		return false, diags
 	}
 
 	remoteOpts := &config.RemoteConfig{
@@ -70,7 +85,13 @@ func gitDeploy(ctx context.Context, d Deployment, cleverRemote string) diag.Diag
 	remote, err := repo.CreateRemote(remoteOpts)
 	if err != nil {
 		diags.AddError("failed to add clever remote", err.Error())
-		return diags
+		return false, diags
+	}
+
+	refSpec := config.RefSpec(fmt.Sprintf("%s:%s", targetCommit, plumbing.Master))
+	if err := refSpec.Validate(); err != nil {
+		diags.AddError("failed to build ref spec to push", err.Error())
+		return false, diags
 	}
 
 	pushOptions := &git.PushOptions{
@@ -78,56 +99,7 @@ func gitDeploy(ctx context.Context, d Deployment, cleverRemote string) diag.Diag
 		Force:      true,
 		Progress:   os.Stdout,
 		Auth:       d.CleverGitAuth,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("%s:%s", currentRef.Name(), plumbing.Master)),
-		},
-	}
-	if d.Commit != nil {
-		refNameOrCommit := *d.Commit
-		var refSpec config.RefSpec
-
-		// can be
-		// refs/heads/[BRANCH]
-		// or
-		// [COMMIT_SHA] a397296e135b24e682a011e31f8e15f2fa8a5a0e
-
-		if IsSHA1(refNameOrCommit) {
-			commit, err := repo.CommitObject(plumbing.NewHash(refNameOrCommit))
-			if err == plumbing.ErrObjectNotFound {
-				diags.AddError("requested commit not found", fmt.Sprintf("no commit '%s'", refNameOrCommit))
-				return diags
-			}
-			if err != nil {
-				diags.AddError("failed to look for commit", err.Error())
-				return diags
-			}
-
-			refSpec = config.RefSpec(fmt.Sprintf("%s:%s", commit.Hash.String(), plumbing.Master))
-		} else {
-			if !strings.HasPrefix(refNameOrCommit, "refs/") {
-				refNameOrCommit = "refs/heads/" + refNameOrCommit
-			}
-
-			// We need to check if provided ref exists (several issues with main/master)
-			ref, err := repo.Storer.Reference(plumbing.ReferenceName(refNameOrCommit))
-			if err == plumbing.ErrReferenceNotFound {
-				diags.AddError("requested reference not found", fmt.Sprintf("no reference named '%s'", refNameOrCommit))
-				return diags
-			}
-			if err != nil {
-				diags.AddError("failed to get reference", err.Error())
-				return diags
-			}
-
-			refSpec = config.RefSpec(fmt.Sprintf("%s:%s", ref.Hash().String(), plumbing.Master))
-		}
-
-		if err := refSpec.Validate(); err != nil {
-			diags.AddError("failed to build ref spec to push", err.Error())
-			return diags
-		}
-
-		pushOptions.RefSpecs = []config.RefSpec{refSpec}
+		RefSpecs:   []config.RefSpec{refSpec},
 	}
 
 	tflog.Debug(ctx, "pushing...", map[string]any{
@@ -138,12 +110,68 @@ func gitDeploy(ctx context.Context, d Deployment, cleverRemote string) diag.Diag
 	if err != nil {
 		if err == git.NoErrAlreadyUpToDate {
 			diags.AddWarning("Git push rejected", "repository is already up-to-date")
-		} else {
-			diags.AddError("failed to push to clever remote", err.Error())
+			return false, diags
 		}
+
+		diags.AddError("failed to push to clever remote", err.Error())
+		return false, diags
 	}
 
-	return diags
+	return true, diags
+}
+
+// resolveTargetCommit resolves the commit hash to deploy: the explicit
+// commit/reference when one is set, the repository HEAD otherwise.
+func resolveTargetCommit(repo *git.Repository, commit *string) (string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if commit == nil {
+		head, err := repo.Head()
+		if err != nil {
+			diags.AddError("failed to get current ref", err.Error())
+			return "", diags
+		}
+
+		return head.Hash().String(), diags
+	}
+
+	refNameOrCommit := *commit
+
+	// can be
+	// refs/heads/[BRANCH]
+	// or
+	// [COMMIT_SHA] a397296e135b24e682a011e31f8e15f2fa8a5a0e
+
+	if IsSHA1(refNameOrCommit) {
+		c, err := repo.CommitObject(plumbing.NewHash(refNameOrCommit))
+		if err == plumbing.ErrObjectNotFound {
+			diags.AddError("requested commit not found", fmt.Sprintf("no commit '%s'", refNameOrCommit))
+			return "", diags
+		}
+		if err != nil {
+			diags.AddError("failed to look for commit", err.Error())
+			return "", diags
+		}
+
+		return c.Hash.String(), diags
+	}
+
+	if !strings.HasPrefix(refNameOrCommit, "refs/") {
+		refNameOrCommit = "refs/heads/" + refNameOrCommit
+	}
+
+	// We need to check if provided ref exists (several issues with main/master)
+	ref, err := repo.Storer.Reference(plumbing.ReferenceName(refNameOrCommit))
+	if err == plumbing.ErrReferenceNotFound {
+		diags.AddError("requested reference not found", fmt.Sprintf("no reference named '%s'", refNameOrCommit))
+		return "", diags
+	}
+	if err != nil {
+		diags.AddError("failed to get reference", err.Error())
+		return "", diags
+	}
+
+	return ref.Hash().String(), diags
 }
 
 func IsSHA1(s string) bool {

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceGo) Create(ctx context.Context, req resource.CreateRequest, res
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceLinux) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceNodeJS) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePython) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceRuby) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceRust) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceStaticApache) Create(ctx context.Context, req resource.CreateRe
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/update.go
+++ b/pkg/resources/application/update.go
@@ -59,14 +59,15 @@ func UpdateApp(ctx context.Context, req UpdateReq) (*CreateRes, diag.Diagnostics
 	}
 	res.Application.Vhosts = *vhostsRes.Payload()
 
-	// Git Deployment (when commit change)
+	// Git Deployment: the target commit (explicit one or repository HEAD) is
+	// compared to the currently deployed commit (CommitID), the push only
+	// happens when they differ
 	gitDeployed := false
 	if req.Deployment != nil {
-		GitDeploy(ctx, req.Deployment, res.Application.DeployURL, &diags)
+		gitDeployed = GitDeploy(ctx, req.Deployment, res.Application.DeployURL, res.Application.CommitID, &diags)
 		if diags.HasError() {
 			return res, diags
 		}
-		gitDeployed = true
 	}
 
 	// trigger restart of the app if needed (when env change)

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceV) Create(ctx context.Context, req resource.CreateRequest, resp
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), &resp.Diagnostics)
+	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/git_test.go
+++ b/pkg/resources/git_test.go
@@ -1,22 +1,28 @@
 package resources_test
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
 	"path"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tests"
+	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+	"go.clever-cloud.dev/client"
 )
 
 // This is a test for local Git repositories, we don't care about the runtime
@@ -89,6 +95,140 @@ func TestAccPython_localGit(t *testing.T) {
 			ConfigStateChecks: []statecheck.StateCheck{
 				// Test the state for provider's populated values
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+			},
+		}},
+	})
+}
+
+// Changing only environment variables on an application deployed from a local
+// repository without a pinned commit must trigger a new deployment (restart):
+// the no-op git push used to be counted as a deployment, so the restart was
+// skipped and the application kept running with the old environment.
+func TestAccApplication_envChangeTriggersNewDeployment(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	cc := client.New(client.WithAutoOauthConfig())
+	rName := acctest.RandomWithPrefix("tf-test-python")
+	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+
+	repoDir := path.Join(os.TempDir(), "tfenvchangerepo")
+	os.RemoveAll(repoDir)       // clean old instance before test
+	defer os.RemoveAll(repoDir) // clean after test
+
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("failed to initialize test repository: %s", err)
+	}
+
+	err = os.WriteFile(path.Join(repoDir, "README.md"), []byte("# Test repository"), 0644)
+	if err != nil {
+		t.Fatalf("failed to write README.md: %s", err)
+	}
+	workTree, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %s", err)
+	}
+
+	_, err = workTree.Add("README.md")
+	if err != nil {
+		t.Fatalf("failed to add README.md: %s", err)
+	}
+
+	_, err = workTree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Terraform",
+			Email: "terraform@localhost",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to commit README.md: %s", err)
+	}
+
+	pythonBlock := helper.NewRessource(
+		"clevercloud_python",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":               rName,
+			"region":             "par",
+			"min_instance_count": 1,
+			"max_instance_count": 1,
+			"smallest_flavor":    "XS",
+			"biggest_flavor":     "XS",
+			"environment":        map[string]any{"MY_KEY": "first"},
+		}),
+		// no commit: the repository HEAD is the deployment target
+		helper.SetBlockValues("deployment", map[string]any{"repository": fmt.Sprintf("file://%s", repoDir)}),
+	)
+
+	// expectDeployments waits for at least count deployments to exist and for
+	// none of them to still be running, so the next step can safely restart the app
+	expectDeployments := func(count int) statecheck.StateCheck {
+		return tests.NewCheckRemoteResource(
+			fullName,
+			func(ctx context.Context, id string) (*[]tmp.DeploymentResponse, error) {
+				deadline := time.Now().Add(5 * time.Minute)
+				for {
+					deploymentsRes := tmp.ListDeployments(ctx, cc, tests.ORGANISATION, id)
+					if deploymentsRes.HasError() {
+						return nil, deploymentsRes.Error()
+					}
+					deployments := *deploymentsRes.Payload()
+
+					running := pkg.HasSome(deployments, func(d tmp.DeploymentResponse) bool {
+						return d.State == "WIP"
+					})
+					if len(deployments) >= count && !running {
+						return &deployments, nil
+					}
+
+					if time.Now().After(deadline) {
+						return nil, fmt.Errorf("expected %d finished deployments, got %d (running: %t)", count, len(deployments), running)
+					}
+					time.Sleep(10 * time.Second)
+				}
+			},
+			func(ctx context.Context, id string, state *tfjson.State, deployments *[]tmp.DeploymentResponse) error {
+				return nil
+			})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			// initial apply: the git push triggers the first deployment
+			ResourceName: rName,
+			Config:       providerBlock.Append(pythonBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				expectDeployments(1),
+			},
+		}, {
+			// same code, only an env var changes: a restart must trigger a second deployment
+			ResourceName: rName,
+			Config: providerBlock.Append(
+				pythonBlock.SetOneValue("environment", map[string]any{"MY_KEY": "second"}),
+			).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				expectDeployments(2),
+				tests.NewCheckRemoteResource(
+					fullName,
+					func(ctx context.Context, id string) (*[]tmp.Env, error) {
+						envRes := tmp.GetAppEnv(ctx, cc, tests.ORGANISATION, id)
+						if envRes.HasError() {
+							return nil, envRes.Error()
+						}
+						return envRes.Payload(), nil
+					},
+					func(ctx context.Context, id string, state *tfjson.State, envs *[]tmp.Env) error {
+						env := pkg.First(*envs, func(e tmp.Env) bool { return e.Name == "MY_KEY" })
+						if env == nil || env.Value != "second" {
+							return tests.AssertError("bad env var value MY_KEY", env, "second")
+						}
+						return nil
+					}),
 			},
 		}},
 	})


### PR DESCRIPTION
## Bug

On an application with a `deployment` block (repository pointing to a local folder, no `commit` pinned), changing only variables in the `environment` block did not restart the application: the env vars were updated through the API, but the app kept running with the old values.

## Root cause

In `UpdateApp`, the git push was attempted unconditionally whenever a `deployment` block was set, and `gitDeployed` was set to `true` even when the push was a no-op (`NoErrAlreadyUpToDate` is only a warning). The explicit restart meant to apply env changes (`TriggerRestart && !gitDeployed`) was then always skipped.

## Fix

Compare desired state to actual state instead of guessing from the push result:

- `resolveTargetCommit` (extracted from `gitDeploy`) resolves the commit to deploy: the explicit commit/ref when set, the repository HEAD otherwise.
- The push is skipped when this target commit equals the currently deployed commit (`CommitID` from the API — already available from the `PUT` response, no extra API call).
- `GitDeploy` now returns whether a deployment was actually triggered (false on equal commits, no-op push, or GitHub-managed deployment), so the restart on env change happens whenever the push didn't already deploy the new environment.

Create call sites pass `""` as deployed commit (never deployed → always push), keeping their behavior unchanged.

## Test

`TestAccApplication_envChangeTriggersNewDeployment` (`pkg/resources/git_test.go`): local repository without a pinned commit; step 1 creates the app (1 deployment), step 2 changes only an env var and asserts through the API that a second deployment was triggered and the new value is set.

Validated: `go build`, `go vet`, unit tests, and the new acceptance test passes against real infrastructure (`TF_ACC=1`).