### PR TITLE
ci: install Terraform CLI on PATH for test and docs jobs

### DIFF
--- a/.github/workflows/doc_sync.yml
+++ b/.github/workflows/doc_sync.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Get dependencies
         run: go mod download
 
+      # Provide a Terraform CLI on PATH so tfplugindocs uses it instead of
+      # hc-install's GPG-verified download (HashiCorp's signing key periodically expires).
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
       - name: Install tfplugindocs
         run: go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
       - name: Run tfplugindocs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,12 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
+    # Provide a Terraform CLI on PATH so tests don't trigger hc-install's
+    # GPG-verified download (HashiCorp's signing key periodically expires).
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_wrapper: false
     - name: Tests
       run: make test
   lint:


### PR DESCRIPTION
## Problem

The `test` and `Auto-updates docs` jobs fail with:
```
unable to verify checksums signature: openpgp: key expired
```
Both let `hc-install` download the Terraform CLI, which verifies HashiCorp's signing key — that key has expired, so the download is rejected (`application/rust` unit test + `tfplugindocs`).

## Fix

Add `hashicorp/setup-terraform@v4` so a Terraform CLI is already on `PATH`:
- `test` job (`lint.yml`): the test helper finds the CLI instead of falling back to `hc-install`.
- `docs-synch` job (`doc_sync.yml`): `tfplugindocs` uses the PATH binary instead of downloading.

This mirrors the `acceptance` jobs, which already use `setup-terraform` and are unaffected by the expired key.

## Note

This is repo-wide CI maintenance, independent of any feature branch. The `acceptance` jobs separately need the `CC_OAUTH_TOKEN`/`CC_OAUTH_SECRET` secrets refreshed (expired OAuth token) — out of scope here.