### PR TITLE
fix(provider): read clever-tools profiles config format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
-	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
@@ -181,6 +180,7 @@ replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20250106
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
+	github.com/adrg/xdg v0.5.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jlaffaye/ftp v0.2.0

--- a/pkg/clevertools/config.go
+++ b/pkg/clevertools/config.go
@@ -1,0 +1,149 @@
+// Package clevertools parses the clever-tools CLI configuration file.
+//
+// clever-tools >= 4.6.0 moved credentials from the config file root into a
+// "profiles" array (to support multiple accounts). The pinned client
+// dependency go.clever-cloud.dev/client@v0.1.7 only understands the legacy
+// root-level format, so it silently fails to find credentials against a
+// modern clever-tools.json. This package understands both formats.
+package clevertools
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/adrg/xdg"
+)
+
+const (
+	configDir      = "clever-cloud"
+	configFileName = "clever-tools.json"
+)
+
+// Overrides holds per-profile consumer key/secret overrides.
+type Overrides struct {
+	OAuthConsumerKey    string `json:"OAUTH_CONSUMER_KEY,omitempty"`
+	OAuthConsumerSecret string `json:"OAUTH_CONSUMER_SECRET,omitempty"`
+}
+
+// Profile is one clever-tools account, as stored in clever-tools.json.
+type Profile struct {
+	Alias          string     `json:"alias"`
+	Token          string     `json:"token"`
+	Secret         string     `json:"secret"`
+	ExpirationDate string     `json:"expirationDate,omitempty"`
+	UserID         string     `json:"userId,omitempty"`
+	Email          string     `json:"email,omitempty"`
+	Overrides      *Overrides `json:"overrides,omitempty"`
+}
+
+// currentFormat is the clever-tools >= 4.6.0 layout.
+type currentFormat struct {
+	Profiles []Profile `json:"profiles"`
+}
+
+// legacyFormat is the flat, single-account layout written by older clever-tools.
+type legacyFormat struct {
+	Token          string `json:"token"`
+	Secret         string `json:"secret"`
+	ExpirationDate string `json:"expirationDate,omitempty"`
+}
+
+// ConfigFilePath resolves the clever-tools config file, mirroring the lookup
+// done by go.clever-cloud.dev/client: XDG config search, falling back to
+// $HOME/.config/... since clever-tools does not honor XDG on macOS. Returns
+// "" if no file is found.
+func ConfigFilePath() string {
+	relPath := fmt.Sprintf("%s/%s", configDir, configFileName)
+
+	path, _ := xdg.SearchConfigFile(relPath)
+	if path != "" {
+		return path
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	fallback := fmt.Sprintf("%s/.config/%s", home, relPath)
+	if _, err := os.Stat(fallback); err == nil {
+		return fallback
+	}
+
+	return ""
+}
+
+// ActiveProfile reads path and returns the active profile, following the
+// clever-tools semantics. A missing file is not an error: (nil, nil).
+func ActiveProfile(path string) (*Profile, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("reading clever-tools config at %q: %w", path, err)
+	}
+
+	return ActiveProfileFrom(content)
+}
+
+// ActiveProfileFrom parses raw clever-tools.json content and returns the
+// active profile: profiles[0] in the current format (clever-tools always
+// moves the freshly authenticated profile there, regardless of alias), or
+// the legacy flat object as a single "default" profile. Returns (nil, nil)
+// when the content is valid JSON but carries no usable credentials, and an
+// error only on malformed JSON.
+func ActiveProfileFrom(content []byte) (*Profile, error) {
+	var current currentFormat
+	if err := json.Unmarshal(content, &current); err != nil {
+		return nil, fmt.Errorf("parsing clever-tools config: %w", err)
+	}
+
+	if len(current.Profiles) > 0 {
+		p := current.Profiles[0]
+		if p.Token == "" || p.Secret == "" {
+			return nil, nil
+		}
+
+		return &p, nil
+	}
+
+	var legacy legacyFormat
+	if err := json.Unmarshal(content, &legacy); err != nil {
+		return nil, fmt.Errorf("parsing clever-tools config: %w", err)
+	}
+
+	if legacy.Token == "" || legacy.Secret == "" {
+		return nil, nil
+	}
+
+	return &Profile{
+		Alias:          "default",
+		Token:          legacy.Token,
+		Secret:         legacy.Secret,
+		ExpirationDate: legacy.ExpirationDate,
+	}, nil
+}
+
+// Expired reports whether the profile's expiration date is in the past. A
+// missing or unparseable date is never treated as expired: it's a cosmetic
+// field the legacy format may lack, and we must not fail closed on it.
+func (p *Profile) Expired() bool {
+	if p == nil || p.ExpirationDate == "" {
+		return false
+	}
+
+	t, err := time.Parse(time.RFC3339, p.ExpirationDate)
+	if err != nil {
+		return false
+	}
+
+	return t.Before(time.Now())
+}

--- a/pkg/clevertools/config_test.go
+++ b/pkg/clevertools/config_test.go
@@ -1,0 +1,166 @@
+package clevertools
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestActiveProfileFrom(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantNil     bool
+		wantErr     bool
+		wantAlias   string
+		wantToken   string
+		wantSecret  string
+		wantCK      string
+		wantCS      string
+		wantOverrid bool
+	}{
+		{
+			name:      "current format, one profile",
+			content:   `{"version":1,"profiles":[{"alias":"perso","token":"tok1","secret":"sec1"}]}`,
+			wantAlias: "perso",
+			wantToken: "tok1",
+			wantSecret: "sec1",
+		},
+		{
+			name: "current format, several profiles returns profiles[0] regardless of alias",
+			content: `{"version":1,"profiles":[
+				{"alias":"work","token":"tok-work","secret":"sec-work"},
+				{"alias":"default","token":"tok-default","secret":"sec-default"}
+			]}`,
+			wantAlias:  "work",
+			wantToken:  "tok-work",
+			wantSecret: "sec-work",
+		},
+		{
+			name:       "legacy flat format",
+			content:    `{"token":"tok-legacy","secret":"sec-legacy","expirationDate":"2099-01-01T00:00:00.000Z"}`,
+			wantAlias:  "default",
+			wantToken:  "tok-legacy",
+			wantSecret: "sec-legacy",
+		},
+		{
+			name:    "empty profiles array means no credentials",
+			content: `{"version":1,"profiles":[]}`,
+			wantNil: true,
+		},
+		{
+			name:    "profile missing token",
+			content: `{"version":1,"profiles":[{"alias":"default","secret":"sec1"}]}`,
+			wantNil: true,
+		},
+		{
+			name:    "profile missing secret",
+			content: `{"version":1,"profiles":[{"alias":"default","token":"tok1"}]}`,
+			wantNil: true,
+		},
+		{
+			name:    "malformed json",
+			content: `{not json`,
+			wantErr: true,
+		},
+		{
+			name:        "profile with overrides",
+			content:     `{"version":1,"profiles":[{"alias":"default","token":"tok1","secret":"sec1","overrides":{"OAUTH_CONSUMER_KEY":"ck","OAUTH_CONSUMER_SECRET":"cs"}}]}`,
+			wantAlias:   "default",
+			wantToken:   "tok1",
+			wantSecret:  "sec1",
+			wantCK:      "ck",
+			wantCS:      "cs",
+			wantOverrid: true,
+		},
+		{
+			name:      "future version with profiles still parses",
+			content:   `{"version":2,"profiles":[{"alias":"default","token":"tok1","secret":"sec1"}]}`,
+			wantAlias: "default",
+			wantToken: "tok1",
+			wantSecret: "sec1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := ActiveProfileFrom([]byte(tt.content))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNil {
+				if profile != nil {
+					t.Fatalf("expected nil profile, got %+v", profile)
+				}
+				return
+			}
+
+			if profile == nil {
+				t.Fatalf("expected a profile, got nil")
+			}
+			if profile.Alias != tt.wantAlias {
+				t.Errorf("Alias = %q, want %q", profile.Alias, tt.wantAlias)
+			}
+			if profile.Token != tt.wantToken {
+				t.Errorf("Token = %q, want %q", profile.Token, tt.wantToken)
+			}
+			if profile.Secret != tt.wantSecret {
+				t.Errorf("Secret = %q, want %q", profile.Secret, tt.wantSecret)
+			}
+
+			if tt.wantOverrid {
+				if profile.Overrides == nil {
+					t.Fatalf("expected overrides, got nil")
+				}
+				if profile.Overrides.OAuthConsumerKey != tt.wantCK {
+					t.Errorf("OAuthConsumerKey = %q, want %q", profile.Overrides.OAuthConsumerKey, tt.wantCK)
+				}
+				if profile.Overrides.OAuthConsumerSecret != tt.wantCS {
+					t.Errorf("OAuthConsumerSecret = %q, want %q", profile.Overrides.OAuthConsumerSecret, tt.wantCS)
+				}
+			}
+		})
+	}
+}
+
+func TestActiveProfile_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	profile, err := ActiveProfile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile != nil {
+		t.Fatalf("expected nil profile for missing file, got %+v", profile)
+	}
+}
+
+func TestProfile_Expired(t *testing.T) {
+	tests := []struct {
+		name string
+		date string
+		want bool
+	}{
+		{"past date", "2000-01-01T00:00:00.000Z", true},
+		{"future date", "2099-01-01T00:00:00.000Z", false},
+		{"empty", "", false},
+		{"garbage", "not-a-date", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Profile{ExpirationDate: tt.date}
+			if got := p.Expired(); got != tt.want {
+				t.Errorf("Expired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/provider/impl/provider_configure.go
+++ b/pkg/provider/impl/provider_configure.go
@@ -6,10 +6,70 @@ import (
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/clevertools"
 	"go.clever-cloud.dev/client"
 )
+
+type oauthCreds struct{ consumerKey, consumerSecret, token, secret string }
+
+// resolveCreds mirrors go.clever-cloud.dev/client credential precedence (env, then
+// clever-tools config) while also understanding the profiles format introduced in
+// clever-tools 4.6.0, which the pinned client v0.1.7 cannot parse.
+func resolveCreds() (*oauthCreds, *clevertools.Profile, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	token, secret := os.Getenv("CC_OAUTH_TOKEN"), os.Getenv("CC_OAUTH_SECRET")
+	if token != "" && secret != "" {
+		return &oauthCreds{
+			consumerKey:    firstNonEmpty(os.Getenv("CC_CONSUMER_KEY"), client.OAUTH_CONSUMER_KEY),
+			consumerSecret: firstNonEmpty(os.Getenv("CC_CONSUMER_SECRET"), client.OAUTH_CONSUMER_SECRET),
+			token:          token,
+			secret:         secret,
+		}, nil, diags
+	}
+
+	path := clevertools.ConfigFilePath()
+
+	profile, err := clevertools.ActiveProfile(path)
+	if err != nil {
+		diags.AddError(
+			"Invalid clever-tools configuration",
+			fmt.Sprintf("Could not read credentials from %q: %s", path, err),
+		)
+
+		return nil, nil, diags
+	}
+
+	if profile == nil {
+		return nil, nil, diags
+	}
+
+	consumerKey, consumerSecret := client.OAUTH_CONSUMER_KEY, client.OAUTH_CONSUMER_SECRET
+	if o := profile.Overrides; o != nil {
+		consumerKey = firstNonEmpty(o.OAuthConsumerKey, consumerKey)
+		consumerSecret = firstNonEmpty(o.OAuthConsumerSecret, consumerSecret)
+	}
+
+	return &oauthCreds{
+		consumerKey:    consumerKey,
+		consumerSecret: consumerSecret,
+		token:          profile.Token,
+		secret:         profile.Secret,
+	}, profile, diags
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
 
 func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var config ProviderData
@@ -55,21 +115,45 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		config.Token.IsUnknown() ||
 		config.Secret.IsNull() ||
 		config.Token.IsNull() {
-		clientOptions = append(clientOptions, client.WithAutoOauthConfig())
+		creds, profile, diags := resolveCreds()
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
-		tmpClient := client.New()
-		c := tmpClient.GuessOauth1Config()
+		if creds == nil {
+			searched := clevertools.ConfigFilePath()
+			if searched == "" {
+				searched = "no clever-tools configuration file found"
+			}
 
-		// Check if GuessOauth1Config returned nil (invalid/missing credentials)
-		if c == nil {
 			resp.Diagnostics.AddError(
 				"CleverCloud authentication empty",
-				"Something went wrong while trying to guess OAuth1 credentials",
+				fmt.Sprintf(
+					"No credentials found (%s).\n\nEither set the CC_OAUTH_TOKEN and CC_OAUTH_SECRET environment variables, run 'clever login', or set the token and secret provider parameters.",
+					searched,
+				),
 			)
 			return
 		}
 
-		p.gitAuth = &http.BasicAuth{Username: c.AccessToken, Password: c.AccessSecret}
+		// An expired token only surfaces as an opaque 401 later on, and the legacy
+		// config format may not carry an expiration date at all: warn, never fail.
+		if profile.Expired() {
+			resp.Diagnostics.AddWarning(
+				"CleverCloud credentials expired",
+				fmt.Sprintf("The clever-tools profile %q expired on %s, run 'clever login' to renew it.", profile.Alias, profile.ExpirationDate),
+			)
+		}
+
+		clientOptions = append(clientOptions, client.WithOauthConfig(
+			creds.consumerKey,
+			creds.consumerSecret,
+			creds.token,
+			creds.secret,
+		))
+
+		p.gitAuth = &http.BasicAuth{Username: creds.token, Password: creds.secret}
 
 	} else {
 		clientOptions = append(clientOptions, client.WithUserOauthConfig(


### PR DESCRIPTION
Since clever-tools 4.6.0, `clever login` nests the credentials in a `profiles` array instead of
writing them at the JSON root:

```json
{ "version": 1, "profiles": [ { "alias": "default", "token": "...", "secret": "..." } ] }
```

The provider delegates credential discovery to `go.clever-cloud.dev/client v0.1.7`, whose
`guessOauth1ConfigFromConfigFile()` unmarshals the whole file into `OAuth1Config{token, secret}`.
Against the new format `json.Unmarshal` succeeds with both fields empty, `GuessOauth1Config()`
returns nil, and the provider fails with `Something went wrong while trying to guess OAuth1
credentials`.

v0.1.7 is the last published version of the client library, so the fix lives provider-side.

## Changes

- New `pkg/clevertools` package parsing both the current (`profiles`) and the legacy flat format.
- `resolveCreds()` in `provider_configure.go` resolves credentials explicitly, preserving the
  library's precedence: `CC_OAUTH_TOKEN` + `CC_OAUTH_SECRET`, then the clever-tools config file.
- Drops the throwaway `client.New()` that only existed to re-resolve credentials for `gitAuth`.
- An expired profile now emits a warning pointing at `clever login`, instead of an opaque 401.
- The "no credentials" error names the config path it searched.

## The active profile is `profiles[0]`

Not the profile whose `alias` is `"default"`. `saveProfile()` in clever-tools always moves the
freshly authenticated profile to the head of the array. Selecting by alias would silently
authenticate a multi-profile user against the wrong account; a test covers this.

## Out of scope

- `CLEVER_TOKEN` / `CLEVER_SECRET` parity: clever-tools injects a virtual `$env` profile for these,
  while the Go library only reads `CC_OAUTH_*`. Widening that changes credential precedence.
- Patching `clevercloud-client-go` upstream. Once it gets a release, `pkg/clevertools` is the
  natural thing to upstream and delete here.

Closes #408
