### PR TITLE
fix(postgresql): refresh connection info after migration, pin computed attrs

### DIFF
--- a/pkg/resources/database/cellar/schema.go
+++ b/pkg/resources/database/cellar/schema.go
@@ -55,11 +55,13 @@ func (r ResourceCellar) Schema(_ context.Context, req resource.SchemaRequest, re
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"key_id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Key ID used to authenticate"},
+				MarkdownDescription: "Key ID used to authenticate",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"key_secret": schema.StringAttribute{
 				Computed:            true,
 				Sensitive:           true,
-				MarkdownDescription: "Key secret used to authenticate"},
+				MarkdownDescription: "Key secret used to authenticate",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 		},
 	}
 }

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -513,6 +513,21 @@ func (r *ResourcePostgreSQL) migrate(ctx context.Context, plan PostgreSQL, state
 				state.Plan = pkg.FromStr(billingPlan.Slug)
 				state.Region = pkg.FromStr(migrationReq.Region)
 				state.Version = pkg.FromStr(*migrationReq.Version)
+
+				// A migration provisions a new instance: connection details change.
+				// Refresh them explicitly since they are pinned via UseStateForUnknown.
+				if pgRes := tmp.GetPostgreSQL(ctx, r.Client(), addonID); pgRes.HasError() {
+					diags.AddWarning("failed to refresh connection info after migration", pgRes.Error().Error())
+				} else {
+					addonPG := pgRes.Payload()
+					state.Host = pkg.FromStr(addonPG.Host)
+					state.Port = pkg.FromI(int64(addonPG.Port))
+					state.Database = pkg.FromStr(addonPG.Database)
+					state.User = pkg.FromStr(addonPG.User)
+					state.Password = pkg.FromStr(addonPG.Password)
+					state.Version = pkg.FromStr(addonPG.Version)
+					state.Uri = pkg.FromStr(addonPG.Uri())
+				}
 				return
 			} else if currentMigration.Status != "RUNNING" {
 				diags.AddError(

--- a/pkg/resources/database/postgresql/schema.go
+++ b/pkg/resources/database/postgresql/schema.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -47,16 +48,17 @@ func (r ResourcePostgreSQL) Schema(_ context.Context, req resource.SchemaRequest
 		Version:             1, // Incremented from 0 due to locale type change from Bool to String
 		MarkdownDescription: resourcePostgresqlDoc,
 		Attributes: addon.WithAddonCommons(map[string]schema.Attribute{
-			"host":     schema.StringAttribute{Computed: true, MarkdownDescription: "Database host, used to connect to"},
-			"port":     schema.Int64Attribute{Computed: true, MarkdownDescription: "Database port"},
-			"database": schema.StringAttribute{Computed: true, MarkdownDescription: "Database name on the PostgreSQL server"},
-			"user":     schema.StringAttribute{Computed: true, MarkdownDescription: "Login username"},
-			"password": schema.StringAttribute{Computed: true, MarkdownDescription: "Login password", Sensitive: true},
-			"uri":      schema.StringAttribute{Computed: true, MarkdownDescription: "Database connection string", Sensitive: true},
+			"host":     schema.StringAttribute{Computed: true, MarkdownDescription: "Database host, used to connect to", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"port":     schema.Int64Attribute{Computed: true, MarkdownDescription: "Database port", PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
+			"database": schema.StringAttribute{Computed: true, MarkdownDescription: "Database name on the PostgreSQL server", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"user":     schema.StringAttribute{Computed: true, MarkdownDescription: "Login username", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"password": schema.StringAttribute{Computed: true, MarkdownDescription: "Login password", Sensitive: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"uri":      schema.StringAttribute{Computed: true, MarkdownDescription: "Database connection string", Sensitive: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"version": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "PostgreSQL version",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 				Validators: []validator.String{
 					pkg.NewStringValidator("Match existing PostgresQL version", r.validatePGVersion),
 				},
@@ -72,13 +74,13 @@ func (r ResourcePostgreSQL) Schema(_ context.Context, req resource.SchemaRequest
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Encrypt the hard drive at rest",
-				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown(), boolplanmodifier.RequiresReplace()},
 			},
 			"direct_host_only": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Connect directly to the database host, bypassing the reverse proxy. Lower latency but no automatic failover on migration.",
-				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown(), boolplanmodifier.RequiresReplace()},
 			},
 			"locale": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
## Problem

Computed connection attributes on `clevercloud_postgresql` (`host`, `port`, `database`, `user`, `password`, `uri`, `version`) and `clevercloud_cellar` credentials (`key_id`, `key_secret`) had no `UseStateForUnknown` plan modifier, so any unrelated plan showed them as `(known after apply)`, causing noisy diffs and needless downstream churn.

Pinning them alone would introduce a real bug though: a plan/region/version change goes through an addon **migration**, which provisions a new instance whose connection details actually do change — values pinned from prior state would then be stale.

## Changes

- `pkg/resources/database/postgresql/schema.go` — add `UseStateForUnknown` to all computed connection attributes, and to the `encryption_at_rest` / `direct_host_only` bools (alongside their existing `RequiresReplace`).
- `pkg/resources/database/postgresql/crud.go` — after a successful migration, explicitly re-fetch the instance and refresh `host`/`port`/`database`/`user`/`password`/`version`/`uri` in state (warning rather than error if the refresh call fails).
- `pkg/resources/database/cellar/schema.go` — add `UseStateForUnknown` to `key_id` / `key_secret`.

## Notes

- No generated-doc changes: plan modifiers don't appear in docs and no descriptions changed.
- Scoped deliberately small; independent of other in-flight work.