### PR TITLE
fix(otoroshi): read API credentials from addon payload, guard nil API

### DIFF
--- a/pkg/resources/software/otoroshi/crud.go
+++ b/pkg/resources/software/otoroshi/crud.go
@@ -65,9 +65,11 @@ func (r *ResourceOtoroshi) Create(ctx context.Context, req resource.CreateReques
 		resp.Diagnostics.AddError("failed to get Otorshi", otoroshiRes.Error().Error())
 	} else {
 		otoroshi := otoroshiRes.Payload()
-		state.APIURL = pkg.FromStr(otoroshi.API.URL)
-		state.APIClientID = pkg.FromStr(otoroshi.EnvVars["CC_OTOROSHI_API_CLIENT_ID"])
-		state.APIClientSecret = pkg.FromStr(otoroshi.EnvVars["CC_OTOROSHI_API_CLIENT_SECRET"])
+		if otoroshi.API != nil {
+			state.APIURL = pkg.FromStr(otoroshi.API.URL)
+			state.APIClientID = pkg.FromStr(otoroshi.API.User)
+			state.APIClientSecret = pkg.FromStr(otoroshi.API.Secret)
+		}
 		state.InitialAdminLogin = pkg.FromStr(otoroshi.Initialredentials.User)
 		state.InitialAdminPassword = pkg.FromStr(otoroshi.Initialredentials.Passsword)
 		state.URL = pkg.FromStr(otoroshi.AccessURL)
@@ -105,9 +107,11 @@ func (r *ResourceOtoroshi) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.AddError("failed to get Otorshi", otoroshiRes.Error().Error())
 	} else {
 		otoroshi := otoroshiRes.Payload()
-		state.APIURL = pkg.FromStr(otoroshi.API.URL)
-		state.APIClientID = pkg.FromStr(otoroshi.EnvVars["CC_OTOROSHI_API_CLIENT_ID"])
-		state.APIClientSecret = pkg.FromStr(otoroshi.EnvVars["CC_OTOROSHI_API_CLIENT_SECRET"])
+		if otoroshi.API != nil {
+			state.APIURL = pkg.FromStr(otoroshi.API.URL)
+			state.APIClientID = pkg.FromStr(otoroshi.API.User)
+			state.APIClientSecret = pkg.FromStr(otoroshi.API.Secret)
+		}
 		state.InitialAdminLogin = pkg.FromStr(otoroshi.Initialredentials.User)
 		state.InitialAdminPassword = pkg.FromStr(otoroshi.Initialredentials.Passsword)
 		state.URL = pkg.FromStr(otoroshi.AccessURL)

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -404,7 +404,9 @@ type OtoroshiInfo struct {
 	} `json:"initialCredentials"`
 }
 type OtoroshiAPI struct {
-	URL string `json:"url"`
+	URL    string `json:"url"`
+	User   string `json:"user"`
+	Secret string `json:"secret"`
 }
 
 // Use real ID


### PR DESCRIPTION
## Problem

The `clevercloud_otoroshi` resource sourced `api_client_id` / `api_client_secret` from the `CC_OTOROSHI_API_CLIENT_ID` / `CC_OTOROSHI_API_CLIENT_SECRET` env vars of the addon payload, while the credentials can be retrieved directly through the API: the operator payload exposes them in its `api` object (`api.user` / `api.secret`). The resource also dereferenced `otoroshi.API` without a nil check, panicking when the payload omits the `api` object.

## Changes

- `pkg/tmp/addon.go` — add `User` / `Secret` fields to the `OtoroshiAPI` struct (`api.user` / `api.secret` in the payload).
- `pkg/resources/software/otoroshi/crud.go` — in both `Create` and `Read`, guard `otoroshi.API != nil` and read `api_url` / `api_client_id` / `api_client_secret` from the `api` object instead of env vars.

## Verification

This is the documented contract: the [v4 operators API reference](https://www.clever.cloud/developers/api/v4/#operators) specifies the `api` object with `url`, `user` and `secret` fields, marked "always returned" for Otoroshi.

Confirmed empirically as well: `TestAccOtoroshi_basic` run against the live API — both steps assert non-empty alphanumeric `api_client_id` / `api_client_secret`.