### PR TITLE
feat: add resource tags and provider-level default_tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ Where:
 
 - `consumer_key` (String) Clever Cloud OAuth1 consumer key. Allows using a dedicated OAuth consumer.
 - `consumer_secret` (String, Sensitive) CleverCloud OAuth1 consumer secret. Allows using a dedicated OAuth consumer.
+- `default_tags` (Set of String) Tags applied to every taggable resource, merged with each resource's own tags. ~> Changing this replaces every `clevercloud_networkgroup` that does not set `ignore_default_tags` (network groups cannot be updated in place, and members are dropped during recreation); all other resource kinds are updated in place.
 - `disable_networkgroups` (Boolean) Disable netorkgroups features
 - `endpoint` (String) Clever Cloud API endpoint, default to https://api.clever-cloud.com
 - `organisation` (String, Sensitive) Clever Cloud organisation, can be either orga_xxx, or user_xxx for personal spaces. This parameter can also be provided via CC_ORGANISATION environment variable.

--- a/docs/resources/addon.md
+++ b/docs/resources/addon.md
@@ -31,12 +31,14 @@ List of available providers:
 
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
 - `configurations` (Map of String, Sensitive) Any configuration exposed by the add-on
 - `creation_date` (Number) Date of database creation
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedatt--networkgroups"></a>
 ### Nested Schema for `networkgroups`

--- a/docs/resources/cellar.md
+++ b/docs/resources/cellar.md
@@ -24,6 +24,7 @@ See [Cellar product specification](https://www.clever.cloud/developers/doc/addon
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the Cellar
 
 ### Read-Only
 
@@ -31,3 +32,4 @@ See [Cellar product specification](https://www.clever.cloud/developers/doc/addon
 - `id` (String) Generated unique identifier
 - `key_id` (String) Key ID used to authenticate
 - `key_secret` (String, Sensitive) Key secret used to authenticate
+- `tags_all` (Set of String) All tags applied to the Cellar: the resource `tags` merged with the provider-level `default_tags`

--- a/docs/resources/configprovider.md
+++ b/docs/resources/configprovider.md
@@ -22,6 +22,11 @@ See [ConfigProvider product specification](https://www.clever.cloud/developers/d
 - `environment` (Map of String, Sensitive) Environment variables injected into the application
 - `name` (String) Name of the service
 
+### Optional
+
+- `tags` (Set of String) Tags of the addon
+
 ### Read-Only
 
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`

--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -19,7 +19,7 @@ See [Docker product specification](https://www.clever.cloud/developers/doc/appli
 
 ```terraform
 resource "clevercloud_docker" "docker_instance" {
-  name = "docker_instance"
+  name   = "docker_instance"
   region = "par"
 
   # horizontal scaling
@@ -29,6 +29,9 @@ resource "clevercloud_docker" "docker_instance" {
   # vertical scaling
   smallest_flavor = "XS"
   biggest_flavor  = "M"
+
+  # Merged with the provider-level `default_tags`; the effective set is exposed as `tags_all`.
+  tags = ["team:backend", "env:prod"]
 }
 ```
 
@@ -76,12 +79,14 @@ environment = { for k, v in {
 - `registry_url` (String) The server of your private registry (optional).	Docker’s public registry
 - `registry_user` (String) The username to login to a private registry
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -113,6 +113,7 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `tfm` (String) Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0
 - `version` (String) Choose the .NET Core version between 6.0, 8.0, 9.0. Default: '8.0'
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -121,6 +122,7 @@ environment = { for k, v in {
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/elasticsearch.md
+++ b/docs/resources/elasticsearch.md
@@ -30,6 +30,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/elast
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `plugins` (Set of String) List of plugins to install
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 - `version` (String) Elasticsearch major version (e.g., '7', '8'). Only the major version number is used by the API. Changing this requires replacing the resource.
 
 ### Read-Only
@@ -44,6 +45,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/elast
 - `kibana_password` (String, Sensitive) Kibana password
 - `kibana_user` (String) Kibana user
 - `password` (String, Sensitive) Login password
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `user` (String) Login username
 
 <a id="nestedatt--networkgroups"></a>

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -60,12 +60,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/fsbucket.md
+++ b/docs/resources/fsbucket.md
@@ -62,6 +62,7 @@ resource "clevercloud_fsbucket" "my_fsbucket" {
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
@@ -69,3 +70,4 @@ resource "clevercloud_fsbucket" "my_fsbucket" {
 - `ftp_username` (String) FTP username used to authenticate
 - `host` (String) FSBucket FTP endpoint
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -115,12 +115,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -116,12 +116,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -116,12 +116,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/keycloak.md
+++ b/docs/resources/keycloak.md
@@ -25,6 +25,7 @@ See [Keycloak product specification](https://www.clever.cloud/developers/doc/add
 
 - `access_domain` (String) Main domaine to access the instance
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 - `version` (String) Keycloak official version
 
 ### Read-Only
@@ -34,3 +35,4 @@ See [Keycloak product specification](https://www.clever.cloud/developers/doc/add
 - `fsbucket_id` (String) ID of the fsbucket subresource
 - `host` (String) URL to access Keycloak
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -128,12 +128,14 @@ environment = { for k, v in {
 - `region` (String) Geographical region where the database will be deployed
 - `run_command` (String) The command to start your application.
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/materia_kv.md
+++ b/docs/resources/materia_kv.md
@@ -24,6 +24,7 @@ See [Materia KV product specification](https://www.clever.cloud/developers/doc/a
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
@@ -31,4 +32,5 @@ See [Materia KV product specification](https://www.clever.cloud/developers/doc/a
 - `host` (String) Database host, used to connect to
 - `id` (String) Generated unique identifier
 - `port` (Number) Database port
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `token` (String, Sensitive) Token to authenticate

--- a/docs/resources/matomo.md
+++ b/docs/resources/matomo.md
@@ -24,9 +24,11 @@ See [Matomo product specification](https://www.clever.cloud/developers/doc/addon
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
 - `host` (String) URL to access Matomo
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `version` (String) Current version of Matomo

--- a/docs/resources/metabase.md
+++ b/docs/resources/metabase.md
@@ -24,8 +24,10 @@ See [Metabase product specification](https://www.clever.cloud/developers/doc/add
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
 - `host` (String) Metabase host, used to connect to
 - `id` (String) Generated unique identifier
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`

--- a/docs/resources/mongodb.md
+++ b/docs/resources/mongodb.md
@@ -28,6 +28,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mongo
 - `encryption` (Boolean) Encrypt the hard drive at rest
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
@@ -37,6 +38,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mongo
 - `id` (String) Generated unique identifier
 - `password` (String, Sensitive) Login password
 - `port` (Number) Database port
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `uri` (String, Sensitive) Database connection string
 - `user` (String) Login username
 

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -31,6 +31,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mysql
 - `read_only_users` (Attributes List) MySQL users with read-only access (see [below for nested schema](#nestedatt--read_only_users))
 - `region` (String) Geographical region where the data will be stored
 - `skip_log_bin` (Boolean) Disable binary logging. Saves disk space but prevents point-in-time recovery and replication.
+- `tags` (Set of String) Tags of the addon
 - `version` (String) MySQL version
 
 ### Read-Only
@@ -41,6 +42,7 @@ See [product specification](https://www.clever.cloud/developers/doc/addons/mysql
 - `id` (String) Generated unique identifier
 - `password` (String, Sensitive) Login password
 - `port` (Number) Database port
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `uri` (String, Sensitive) Database connection string
 - `user` (String) Login username
 

--- a/docs/resources/networkgroup.md
+++ b/docs/resources/networkgroup.md
@@ -4,6 +4,7 @@ page_title: "clevercloud_networkgroup Resource - terraform-provider-clevercloud"
 description: |-
   Manage any Network Group https://www.clever.cloud/developers/doc/develop/network-groups/.
   See Network Groups product specification https://www.clever.cloud/developers/doc/develop/network-groups/.
+  ~> Network groups cannot be updated in place: any change to the effective tag set (the resource tags, or the provider-level default_tags unless ignore_default_tags is set) replaces the network group, dropping its members during recreation. Set ignore_default_tags = true to shield a network group from provider-level tag changes.
 ---
 
 # clevercloud_networkgroup (Resource)
@@ -11,6 +12,8 @@ description: |-
 Manage any [Network Group](https://www.clever.cloud/developers/doc/develop/network-groups/).
 
 See [Network Groups product specification](https://www.clever.cloud/developers/doc/develop/network-groups/).
+
+~> Network groups cannot be updated in place: any change to the effective tag set (the resource `tags`, or the provider-level `default_tags` unless `ignore_default_tags` is set) **replaces the network group**, dropping its members during recreation. Set `ignore_default_tags = true` to shield a network group from provider-level tag changes.
 
 
 
@@ -24,9 +27,11 @@ See [Network Groups product specification](https://www.clever.cloud/developers/d
 ### Optional
 
 - `description` (String) Description of the network group
-- `tags` (Set of String) Tags of the network group
+- `ignore_default_tags` (Boolean) When true, the provider-level `default_tags` are not merged into this network group. Changing this replaces the resource.
+- `tags` (Set of String) Tags of the network group. Network groups cannot be updated in place, so changing tags replaces the resource.
 
 ### Read-Only
 
 - `id` (String) Generated unique identifier
 - `network` (String) Network CIDR of the network group
+- `tags_all` (Set of String) All tags applied to the network group: the resource `tags` merged with the provider-level `default_tags` (unless `ignore_default_tags` is set)

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -120,12 +120,14 @@ environment = { for k, v in {
 - `registry_token` (String, Sensitive) Private repository token
 - `start_script` (String) Set custom start script, instead of `npm start`
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/otoroshi.md
+++ b/docs/resources/otoroshi.md
@@ -34,6 +34,7 @@ Learn more about [Otoroshi with LLM](https://www.clever.cloud/developers/doc/add
 ### Optional
 
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the Otoroshi
 - `version` (String) Otoroshi version to deploy
 
 ### Read-Only
@@ -45,4 +46,5 @@ Learn more about [Otoroshi with LLM](https://www.clever.cloud/developers/doc/add
 - `id` (String) Generated unique identifier
 - `initial_admin_login` (String) Initial admin login
 - `initial_admin_password` (String, Sensitive) Initial admin password
+- `tags_all` (Set of String) All tags applied to the Otoroshi: the resource `tags` merged with the provider-level `default_tags`
 - `url` (String) URL

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -55,6 +55,7 @@ environment = { for k, v in {
 - `redis_sessions` (Boolean) Use a linked Redis instance to store sessions (Default: false)
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 - `webroot` (String) Define the DocumentRoot of your project (default: ".")
 
@@ -62,6 +63,7 @@ environment = { for k, v in {
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -115,12 +115,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/postgresql.md
+++ b/docs/resources/postgresql.md
@@ -19,6 +19,9 @@ resource "clevercloud_postgresql" "postgresql_database" {
   name   = "postgresql_database"
   plan   = "dev"
   region = "par"
+
+  # Merged with the provider-level `default_tags`; the effective set is exposed as `tags_all`.
+  tags = ["team:data", "env:prod"]
 }
 ```
 
@@ -38,6 +41,7 @@ resource "clevercloud_postgresql" "postgresql_database" {
 - `locale` (String) Database locale for collation and character classification. Must be in format 'language_COUNTRY' (e.g., 'en_GB', 'fr_FR'). Only available on dedicated plans. If not specified, defaults to 'en_GB'.
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 - `version` (String) PostgreSQL version
 
 ### Read-Only
@@ -48,6 +52,7 @@ resource "clevercloud_postgresql" "postgresql_database" {
 - `id` (String) Generated unique identifier
 - `password` (String, Sensitive) Login password
 - `port` (Number) Database port
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `uri` (String, Sensitive) Database connection string
 - `user` (String) Login username
 

--- a/docs/resources/pulsar.md
+++ b/docs/resources/pulsar.md
@@ -26,6 +26,7 @@ See [Pulsar product specification](https://www.clever.cloud/developers/doc/addon
 - `region` (String) Geographical region where the data will be stored
 - `retention_period` (Number) Pulsar namespace retention policy in minutes
 - `retention_size` (Number) Pulsar namespace retention policy in bytes
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
@@ -33,5 +34,6 @@ See [Pulsar product specification](https://www.clever.cloud/developers/doc/addon
 - `http_url` (String) Pulsar REST API address
 - `id` (String) Generated unique identifier
 - `namespace` (String) Pulsar namespace
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `tenant` (String) Pulsar tenant
 - `token` (String, Sensitive) Pulsar authentication token

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -117,12 +117,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -26,6 +26,7 @@ See [Redis product specification](https://www.clever.cloud/developers/doc/addons
 
 - `networkgroups` (Attributes Set) List of networkgroups the addon must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
+- `tags` (Set of String) Tags of the addon
 
 ### Read-Only
 
@@ -33,6 +34,7 @@ See [Redis product specification](https://www.clever.cloud/developers/doc/addons
 - `host` (String) Database host, used to connect to
 - `id` (String) Generated unique identifier
 - `port` (Number) Database port
+- `tags_all` (Set of String) All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`
 - `token` (String, Sensitive) Token to authenticate
 
 <a id="nestedatt--networkgroups"></a>

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -202,12 +202,14 @@ environment = { for k, v in {
 - `static_url_prefix` (String) The URL path under which you want to serve static files, usually /public
 - `static_webroot` (String) Path to the web content to serve, relative to the root of your application
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -116,12 +116,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -115,12 +115,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -118,12 +118,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -151,12 +151,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -113,12 +113,14 @@ environment = { for k, v in {
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
+- `tags` (Set of String) Tags of the application
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
 
 ### Read-Only
 
 - `deploy_url` (String) Git URL used to push source code
 - `id` (String) Unique identifier generated during application creation
+- `tags_all` (Set of String) All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`
 
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -14,12 +14,18 @@ variable "organisation" {
 
 provider "clevercloud" {
   organisation = var.organisation
+
+  # Tags applied to every taggable resource, merged with each resource's own `tags`.
+  default_tags = ["managed-by:terraform", "env:demo"]
 }
 
 resource "clevercloud_postgresql" "PG1" {
   name = "PG1"
   plan = "dev"
   region = "par"
+
+  # Merged with the provider `default_tags`; the effective set is exposed as `tags_all`.
+  tags = ["team:data"]
 }
 
 resource "clevercloud_nodejs" "node1" {
@@ -30,16 +36,19 @@ resource "clevercloud_nodejs" "node1" {
 	smallest_flavor = "XS"
 	biggest_flavor = "M"
 	node_version = "14.0"
+	tags = ["team:backend"]
 }
 
 resource "clevercloud_cellar" "cellar1" {
   name = "cellar1"
   region = "par"
+
+  # A resource with no `tags` still receives the provider `default_tags` via `tags_all`.
 }
 
 resource "clevercloud_cellar_bucket" "bucket1" {
   id = "bucket1"
-  cellar_id = cellar1.id
+  cellar_id = clevercloud_cellar.cellar1.id
 }
 
 output "host" {
@@ -48,4 +57,10 @@ output "host" {
 
 output "ID" {
   value = clevercloud_postgresql.PG1.id
+}
+
+# Effective tags: the resource `tags` merged with the provider `default_tags`.
+# => ["env:demo", "managed-by:terraform", "team:data"]
+output "postgresql_tags_all" {
+  value = clevercloud_postgresql.PG1.tags_all
 }

--- a/examples/resources/clevercloud_docker/resource.tf
+++ b/examples/resources/clevercloud_docker/resource.tf
@@ -1,5 +1,5 @@
 resource "clevercloud_docker" "docker_instance" {
-  name = "docker_instance"
+  name   = "docker_instance"
   region = "par"
 
   # horizontal scaling
@@ -9,4 +9,7 @@ resource "clevercloud_docker" "docker_instance" {
   # vertical scaling
   smallest_flavor = "XS"
   biggest_flavor  = "M"
+
+  # Merged with the provider-level `default_tags`; the effective set is exposed as `tags_all`.
+  tags = ["team:backend", "env:prod"]
 }

--- a/examples/resources/clevercloud_postgresql/resource.tf
+++ b/examples/resources/clevercloud_postgresql/resource.tf
@@ -2,4 +2,7 @@ resource "clevercloud_postgresql" "postgresql_database" {
   name   = "postgresql_database"
   plan   = "dev"
   region = "par"
+
+  # Merged with the provider-level `default_tags`; the effective set is exposed as `tags_all`.
+  tags = ["team:data", "env:prod"]
 }

--- a/pkg/helper/provider_block.go
+++ b/pkg/helper/provider_block.go
@@ -10,6 +10,7 @@ import (
 type Provider struct {
 	provider     string
 	organisation string
+	keyValues    map[string]any
 	blocks       []fmt.Stringer
 }
 
@@ -44,6 +45,13 @@ func (p *Provider) SetOrganisation(orgName string) *Provider {
 	return p
 }
 
+// SetKeyValues sets additional provider-level attributes (e.g. default_tags),
+// rendered inside the provider block alongside organisation.
+func (p *Provider) SetKeyValues(kv map[string]any) *Provider {
+	p.keyValues = kv
+	return p
+}
+
 func (p *Provider) Append(blocks ...fmt.Stringer) *Provider {
 	p.blocks = blocks
 	return p
@@ -56,7 +64,9 @@ func (p *Provider) Append(blocks ...fmt.Stringer) *Provider {
 func (p *Provider) String() string {
 	s := `provider "` + p.provider + `" {
 	organisation = "` + p.organisation + `"
-}
+`
+	s = map_String(p.keyValues, s, "\t", " =")
+	s += `}
 ` + pkg.Reduce(p.blocks, "", func(acc string, block fmt.Stringer) string {
 		return acc + block.String() + "\n"
 	})

--- a/pkg/provider/impl/provider.go
+++ b/pkg/provider/impl/provider.go
@@ -13,6 +13,7 @@ type Provider struct {
 	gitAuth                *http.BasicAuth
 	organization           string
 	isNetwrkgroupsDisabled bool
+	tags                   []string
 }
 
 func New(version string) func() provider.Provider {
@@ -34,4 +35,8 @@ func (p *Provider) GitAuth() *http.BasicAuth {
 
 func (p *Provider) IsNetwrkgroupsDisabled() bool {
 	return p.isNetwrkgroupsDisabled
+}
+
+func (p *Provider) DefaultTags() []string {
+	return p.tags
 }

--- a/pkg/provider/impl/provider_configure.go
+++ b/pkg/provider/impl/provider_configure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/clevertools"
 	"go.clever-cloud.dev/client"
 )
@@ -82,6 +83,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	}
 
 	p.isNetwrkgroupsDisabled = config.DisableNetworkgroup.ValueBool()
+	p.tags = pkg.SetToStringSlice(ctx, config.DefaultTags, &resp.Diagnostics)
 
 	p.organization = os.Getenv("CC_ORGANISATION")
 	if !config.Organisation.IsUnknown() && !config.Organisation.IsNull() {

--- a/pkg/provider/impl/provider_schema.go
+++ b/pkg/provider/impl/provider_schema.go
@@ -21,6 +21,7 @@ type ProviderData struct {
 	ConsumerKey         types.String `tfsdk:"consumer_key"`
 	ConsumerSecret      types.String `tfsdk:"consumer_secret"`
 	DisableNetworkgroup types.Bool   `tfsdk:"disable_networkgroups"`
+	DefaultTags         types.Set    `tfsdk:"default_tags"`
 }
 
 //go:embed provider.md
@@ -65,6 +66,14 @@ func (p *Provider) Schema(_ context.Context, req provider.SchemaRequest, res *pr
 			"disable_networkgroups": schema.BoolAttribute{
 				Optional:            true,
 				MarkdownDescription: "Disable netorkgroups features",
+			},
+			"default_tags": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				MarkdownDescription: "Tags applied to every taggable resource, merged with each resource's own tags. " +
+					"~> Changing this replaces every `clevercloud_networkgroup` that does not set `ignore_default_tags` " +
+					"(network groups cannot be updated in place, and members are dropped during recreation); " +
+					"all other resource kinds are updated in place.",
 			},
 		},
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -10,4 +10,7 @@ type Provider interface {
 	Client() *client.Client
 	GitAuth() *http.BasicAuth
 	IsNetwrkgroupsDisabled() bool
+	// DefaultTags returns the tags configured at provider level, which are merged
+	// into every taggable resource's own tags.
+	DefaultTags() []string
 }

--- a/pkg/resources/addon/addon_test.go
+++ b/pkg/resources/addon/addon_test.go
@@ -21,7 +21,8 @@ func TestAccAddon_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-mp")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_addon.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	addonBlock := helper.NewRessource(
 		"clevercloud_addon",
 		rName,
@@ -30,6 +31,7 @@ func TestAccAddon_basic(t *testing.T) {
 			"region":               "par",
 			"plan":                 "clever_solo",
 			"third_party_provider": "mailpace",
+			"tags":                 []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -42,6 +44,15 @@ func TestAccAddon_basic(t *testing.T) {
 			ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^addon_.*`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				// TODO test env var existance
 			},
 		}, {

--- a/pkg/resources/addon/attributes.go
+++ b/pkg/resources/addon/attributes.go
@@ -18,6 +18,8 @@ type CommonAttributes struct {
 	Region        types.String `tfsdk:"region"`
 	CreationDate  types.Int64  `tfsdk:"creation_date"`
 	Networkgroups types.Set    `tfsdk:"networkgroups"`
+	Tags          types.Set    `tfsdk:"tags"`
+	TagsAll       types.Set    `tfsdk:"tags_all"`
 }
 
 var addonCommon = map[string]schema.Attribute{
@@ -35,6 +37,16 @@ var addonCommon = map[string]schema.Attribute{
 		MarkdownDescription: "Geographical region where the data will be stored",
 	},
 	"creation_date": schema.Int64Attribute{Computed: true, MarkdownDescription: "Date of database creation", PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
+	"tags": schema.SetAttribute{
+		ElementType:         types.StringType,
+		Optional:            true,
+		MarkdownDescription: "Tags of the addon",
+	},
+	"tags_all": schema.SetAttribute{
+		ElementType:         types.StringType,
+		Computed:            true,
+		MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+	},
 	"networkgroups": schema.SetNestedAttribute{
 		Optional:            true,
 		MarkdownDescription: "List of networkgroups the addon must be part of",

--- a/pkg/resources/addon/crud.go
+++ b/pkg/resources/addon/crud.go
@@ -11,8 +11,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceAddon) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Addon](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceAddon) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -68,6 +86,8 @@ func (r *ResourceAddon) Create(ctx context.Context, req resource.CreateRequest, 
 	})
 	ad.Configurations = types.MapValueMust(types.StringType, envAsMap)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, res.Payload().ID, ad.Tags, &ad.Tags, &ad.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, ad)...)
 }
 
@@ -116,6 +136,8 @@ func (r *ResourceAddon) Read(ctx context.Context, req resource.ReadRequest, resp
 	ad.CreationDate = pkg.FromI(a.CreationDate)
 	ad.Configurations = types.MapValueMust(types.StringType, envAsMap)
 
+	ad.Tags, ad.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, ad.ID.ValueString(), ad.Tags, &resp.Diagnostics)
+
 	diags = resp.State.Set(ctx, ad)
 	resp.Diagnostics.Append(diags...)
 }
@@ -142,6 +164,8 @@ func (r *ResourceAddon) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/application/create.go
+++ b/pkg/resources/application/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 	"go.clever-cloud.dev/client"
 )
@@ -163,6 +164,9 @@ func Create[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan T
 	if createRes != nil {
 		runtime.ID = pkg.FromStr(createRes.Application.ID)
 		runtime.SetFromResponse(createRes, ctx, &diags)
+
+		// Apply the union of provider default_tags and the resource tags.
+		resources.SyncTags(ctx, resource, resources.ApplicationTags, runtime.ID.ValueString(), runtime.Tags, &runtime.Tags, &runtime.TagsAll, &diags)
 	}
 
 	return diags

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -91,7 +92,7 @@ func (r *ResourceDocker) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *ResourceDocker) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -101,4 +102,9 @@ func (r *ResourceDocker) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "docker", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/docker/docker_test.go
+++ b/pkg/resources/application/docker/docker_test.go
@@ -21,7 +21,8 @@ func TestAccDocker_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test-docker")
 	fullName := fmt.Sprintf("clevercloud_docker.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	dockerBlock := helper.NewRessource(
 		"clevercloud_docker",
 		rName,
@@ -32,6 +33,7 @@ func TestAccDocker_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -45,6 +47,17 @@ func TestAccDocker_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				// resource-level tags exclude the provider default_tags
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				// tags_all merges resource tags with provider default_tags
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceDotnet) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *ResourceDotnet) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceDotnet) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "dotnet", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/dotnet/dotnet_test.go
+++ b/pkg/resources/application/dotnet/dotnet_test.go
@@ -29,7 +29,8 @@ func TestAccDotnet_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-test-dotnet-2")
 	fullName := fmt.Sprintf("clevercloud_dotnet.%s", rName)
 	fullName2 := fmt.Sprintf("clevercloud_dotnet.%s", rName2)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	dotnetBlock := helper.NewRessource(
 		"clevercloud_dotnet",
 		rName,
@@ -49,6 +50,7 @@ func TestAccDotnet_basic(t *testing.T) {
 			"proj":               "dotnet-proj-name",
 			"tfm":                "net42",
 			"version":            "9.0",
+			"tags":               []string{"foo", "bar"},
 		}),
 		helper.SetBlockValues("hooks", map[string]any{"post_build": "echo \"build is OK!\""}),
 	)
@@ -79,6 +81,15 @@ func TestAccDotnet_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("XL")),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -93,7 +94,7 @@ func (r *ResourceFrankenPHP) Update(ctx context.Context, req resource.UpdateRequ
 }
 
 func (r *ResourceFrankenPHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -103,4 +104,9 @@ func (r *ResourceFrankenPHP) ModifyPlan(ctx context.Context, req resource.Modify
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "frankenphp", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/frankenphp/frankenphp_test.go
+++ b/pkg/resources/application/frankenphp/frankenphp_test.go
@@ -26,7 +26,8 @@ func TestAccFrankenPHP_basic(t *testing.T) {
 	cc := client.New(client.WithAutoOauthConfig())
 	rName := acctest.RandomWithPrefix("tf-test-frankenphp")
 	fullName := fmt.Sprintf("clevercloud_frankenphp.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	domain := fmt.Sprintf("%s.com", rName)
 	domainEdit1 := rName + "-1.com"
 	domainEdit2 := rName + "-2.com"
@@ -42,6 +43,7 @@ func TestAccFrankenPHP_basic(t *testing.T) {
 			"biggest_flavor":     "M",
 			"dev_dependencies":   false,
 			"vhosts":             []map[string]string{{"fqdn": domain}},
+			"tags":               []string{"foo", "bar"},
 		}),
 	)
 
@@ -55,6 +57,15 @@ func TestAccFrankenPHP_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("dev_dependencies"), knownvalue.Bool(false)),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceGo) Update(ctx context.Context, req resource.UpdateRequest, res
 }
 
 func (r *ResourceGo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceGo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequ
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "go", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/golang/go_test.go
+++ b/pkg/resources/application/golang/go_test.go
@@ -33,7 +33,8 @@ func TestAccGo_basic(t *testing.T) {
 	cc := client.New(client.WithAutoOauthConfig())
 	rName := acctest.RandomWithPrefix("tf-test-go")
 	fullName := fmt.Sprintf("clevercloud_go.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	goBlock := helper.NewRessource(
 		"clevercloud_go",
 		rName,
@@ -50,6 +51,7 @@ func TestAccGo_basic(t *testing.T) {
 			"app_folder":         "./app",
 			"environment":        map[string]any{"MY_KEY": "myval"},
 			"dependencies":       []string{},
+			"tags":               []string{"foo", "bar"},
 		}),
 		helper.SetBlockValues("hooks", map[string]any{"post_build": "echo \"build is OK!\""}),
 	)
@@ -64,6 +66,15 @@ func TestAccGo_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("M")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("vhosts"), knownvalue.SetExact(
 					[]knownvalue.Check{

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceJava) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *ResourceJava) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceJava) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, r.profile, plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/java/java_test.go
+++ b/pkg/resources/application/java/java_test.go
@@ -24,7 +24,8 @@ func TestAccJava_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test-java")
 	fullName := fmt.Sprintf("clevercloud_java_war.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	javaBlock := helper.NewRessource(
 		"clevercloud_java_war",
 		rName,
@@ -35,6 +36,7 @@ func TestAccJava_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -48,6 +50,15 @@ func TestAccJava_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceLinux) Update(ctx context.Context, req resource.UpdateRequest, 
 }
 
 func (r *ResourceLinux) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceLinux) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "linux", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/linux/linux_test.go
+++ b/pkg/resources/application/linux/linux_test.go
@@ -26,7 +26,8 @@ func TestAccLinux_basic(t *testing.T) {
 	cc := client.New(client.WithAutoOauthConfig())
 	rName := acctest.RandomWithPrefix("tf-test-linux")
 	fullName := fmt.Sprintf("clevercloud_linux.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	linuxBlock := helper.NewRessource(
 		"clevercloud_linux",
 		rName,
@@ -48,6 +49,7 @@ func TestAccLinux_basic(t *testing.T) {
 			"makefile":           "Makefile.custom",
 			"mise_file_path":     "./tools/mise.toml",
 			"disable_mise":       true,
+			"tags":               []string{"foo", "bar"},
 		}),
 		helper.SetBlockValues("hooks", map[string]any{"post_build": "echo \"build is OK!\""}),
 	)
@@ -63,6 +65,15 @@ func TestAccLinux_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("XL")),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceNodeJS) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *ResourceNodeJS) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceNodeJS) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "node", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/nodejs/nodejs_test.go
+++ b/pkg/resources/application/nodejs/nodejs_test.go
@@ -30,7 +30,8 @@ func TestAccNodejs_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-test-node-2")
 	fullName := fmt.Sprintf("clevercloud_nodejs.%s", rName)
 	fullName2 := fmt.Sprintf("clevercloud_nodejs.%s", rName2)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	nodejsBlock := helper.NewRessource(
 		"clevercloud_nodejs",
 		rName,
@@ -47,6 +48,7 @@ func TestAccNodejs_basic(t *testing.T) {
 			"app_folder":         "./app",
 			"environment":        map[string]any{"MY_KEY": "myval"},
 			"dependencies":       []string{},
+			"tags":               []string{"foo", "bar"},
 		}),
 		helper.SetBlockValues("hooks", map[string]any{"post_build": "echo \"build is OK!\""}),
 	)
@@ -63,7 +65,7 @@ func TestAccNodejs_basic(t *testing.T) {
 		}),
 		helper.SetBlockValues("deployment", map[string]any{
 			"repository": "https://github.com/CleverCloud/nodejs-example.git",
-			"commit":     "84cc90cc76abeda2a425ed23d1881f398a30857a",
+			"commit":     "2474d0e99089096f2e5548e19a2c0ad0f684c674",
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -78,6 +80,15 @@ func TestAccNodejs_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("XL")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)
 					if appRes.HasError() {

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -91,7 +92,7 @@ func (r *ResourcePHP) Update(ctx context.Context, req resource.UpdateRequest, re
 }
 
 func (r *ResourcePHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -101,4 +102,9 @@ func (r *ResourcePHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "php", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/php/php_test.go
+++ b/pkg/resources/application/php/php_test.go
@@ -21,7 +21,8 @@ func TestAccPHP_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test-php")
 	fullName := fmt.Sprintf("clevercloud_php.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	phpBlock := helper.NewRessource(
 		"clevercloud_php",
 		rName,
@@ -33,6 +34,7 @@ func TestAccPHP_basic(t *testing.T) {
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
 			"php_version":        "8",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -45,6 +47,15 @@ func TestAccPHP_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourcePlay2) Update(ctx context.Context, req resource.UpdateRequest, 
 }
 
 func (r *ResourcePlay2) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourcePlay2) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "play2", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/play2/scala_test.go
+++ b/pkg/resources/application/play2/scala_test.go
@@ -20,7 +20,8 @@ func TestAccPlay2_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-play2")
 	fullName := fmt.Sprintf("clevercloud_play2.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	play2Block := helper.NewRessource(
 		"clevercloud_play2",
 		rName,
@@ -31,6 +32,7 @@ func TestAccPlay2_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -44,6 +46,15 @@ func TestAccPlay2_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -91,7 +92,7 @@ func (r *ResourcePython) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *ResourcePython) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -101,4 +102,9 @@ func (r *ResourcePython) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "python", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/python/python_test.go
+++ b/pkg/resources/application/python/python_test.go
@@ -32,7 +32,8 @@ func TestAccPython_basic(t *testing.T) {
 	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
 	fullName2 := fmt.Sprintf("clevercloud_python.%s", rName2)
 	vhost := "bubhbfbnriubielrbeuvieuv.com"
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	pythonBlock := helper.NewRessource(
 		"clevercloud_python",
 		rName,
@@ -48,6 +49,7 @@ func TestAccPython_basic(t *testing.T) {
 			"app_folder":         "./app",
 			"python_version":     "2.7",
 			"pip_requirements":   "requirements.txt",
+			"tags":               []string{"foo", "bar"},
 			"environment": map[string]any{
 				"MY_KEY": "myval",
 			},
@@ -66,6 +68,15 @@ func TestAccPython_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)
 					if appRes.HasError() {

--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -151,5 +151,8 @@ func Read[T RuntimePlan](ctx context.Context, resource RuntimeResource, state T)
 	// Map API response to state
 	runtime.SetFromResponse(readRes, ctx, &diags)
 
+	// Read tags: resource-level tags exclude provider default_tags; tags_all keeps them.
+	runtime.Tags, runtime.TagsAll = resources.ReadTags(ctx, resource, resources.ApplicationTags, runtime.ID.ValueString(), runtime.Tags, &diags)
+
 	return false, diags
 }

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceRuby) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *ResourceRuby) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceRuby) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "ruby", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/ruby/ruby_test.go
+++ b/pkg/resources/application/ruby/ruby_test.go
@@ -26,7 +26,8 @@ func TestAccRuby_basic(t *testing.T) {
 	cc := client.New(client.WithAutoOauthConfig())
 	rName := acctest.RandomWithPrefix("tf-test-ruby")
 	fullName := fmt.Sprintf("clevercloud_ruby.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	rubyBlock := helper.NewRessource(
 		"clevercloud_ruby",
 		rName,
@@ -54,6 +55,7 @@ func TestAccRuby_basic(t *testing.T) {
 			"static_url_prefix":       "/assets",
 			"environment":             map[string]any{"MY_KEY": "myval", "RAILS_SECRET": "secret123"},
 			"dependencies":            []string{},
+			"tags":                    []string{"foo", "bar"},
 		}),
 		helper.SetBlockValues("hooks", map[string]any{"post_build": "bundle exec rake assets:precompile"}),
 	)
@@ -69,6 +71,15 @@ func TestAccRuby_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("XL")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("ruby_version"), knownvalue.StringExact("3.3")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("enable_sidekiq"), knownvalue.Bool(true)),

--- a/pkg/resources/application/runtime.go
+++ b/pkg/resources/application/runtime.go
@@ -47,6 +47,8 @@ type Runtime struct {
 	DeployURL        types.String             `tfsdk:"deploy_url"`
 	Dependencies     types.Set                `tfsdk:"dependencies"`
 	Networkgroups    types.Set                `tfsdk:"networkgroups"`
+	Tags             types.Set                `tfsdk:"tags"`
+	TagsAll          types.Set                `tfsdk:"tags_all"`
 	Deployment       *attributes.Deployment   `tfsdk:"deployment"`
 	Hooks            *attributes.Hooks        `tfsdk:"hooks"`
 	Integrations     *attributes.Integrations `tfsdk:"integrations"`

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -91,7 +92,7 @@ func (r *ResourceRust) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *ResourceRust) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -101,4 +102,9 @@ func (r *ResourceRust) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "rust", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/rust/rust_test.go
+++ b/pkg/resources/application/rust/rust_test.go
@@ -19,7 +19,8 @@ func TestAccRust_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test-rust")
 	fullName := fmt.Sprintf("clevercloud_rust.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	rustBlock := helper.NewRessource(
 		"clevercloud_rust",
 		rName,
@@ -37,6 +38,7 @@ func TestAccRust_basic(t *testing.T) {
 			"environment":        map[string]any{"MY_KEY": "myval"},
 			"dependencies":       []string{},
 			"features":           []string{"feature1", "feature2"},
+			"tags":               []string{"foo", "bar"},
 		}),
 	)
 
@@ -61,6 +63,15 @@ func TestAccRust_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("dependencies"), knownvalue.ListSizeExact(0)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`app_.*`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`git\+ssh://.*`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			Config: providerBlock.String() + helper.NewRessource(

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceScala) Update(ctx context.Context, req resource.UpdateRequest, 
 }
 
 func (r *ResourceScala) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceScala) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "sbt", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/scala/scala_test.go
+++ b/pkg/resources/application/scala/scala_test.go
@@ -21,7 +21,8 @@ func TestAccScala_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test")
 	fullName := fmt.Sprintf("clevercloud_scala.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	scalaBlock := helper.NewRessource(
 		"clevercloud_scala",
 		rName,
@@ -32,6 +33,7 @@ func TestAccScala_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -45,6 +47,15 @@ func TestAccScala_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -191,6 +191,16 @@ var runtimeCommon = map[string]schema.Attribute{
 		},
 	},
 	"integrations": attributes.IntegrationsAttribute,
+	"tags": schema.SetAttribute{
+		ElementType:         types.StringType,
+		Optional:            true,
+		MarkdownDescription: "Tags of the application",
+	},
+	"tags_all": schema.SetAttribute{
+		ElementType:         types.StringType,
+		Computed:            true,
+		MarkdownDescription: "All tags applied to the application: the resource `tags` merged with the provider-level `default_tags`",
+	},
 }
 
 // runtimeCommonV0 defines common schema attributes for schema version 0 (for state upgrades)

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceStatic) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *ResourceStatic) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceStatic) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "static", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/static/static_test.go
+++ b/pkg/resources/application/static/static_test.go
@@ -19,7 +19,8 @@ func TestAccStatic_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test")
 	fullName := fmt.Sprintf("clevercloud_static.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	staticBlock := helper.NewRessource(
 		"clevercloud_static",
 		rName,
@@ -30,6 +31,7 @@ func TestAccStatic_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -43,6 +45,15 @@ func TestAccStatic_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceStaticApache) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *ResourceStaticApache) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceStaticApache) ModifyPlan(ctx context.Context, req resource.Modi
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "static-apache", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/staticapache/static_apache_test.go
+++ b/pkg/resources/application/staticapache/static_apache_test.go
@@ -19,7 +19,8 @@ func TestAccStaticApache_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test")
 	fullName := fmt.Sprintf("clevercloud_static_apache.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	staticBlock := helper.NewRessource(
 		"clevercloud_static_apache",
 		rName,
@@ -30,6 +31,7 @@ func TestAccStaticApache_basic(t *testing.T) {
 			"max_instance_count": 2,
 			"smallest_flavor":    "XS",
 			"biggest_flavor":     "M",
+			"tags":               []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -43,6 +45,15 @@ func TestAccStaticApache_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/application/update.go
+++ b/pkg/resources/application/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 	"go.clever-cloud.dev/client"
 )
@@ -158,6 +159,9 @@ func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, 
 	// Sync response even if there were errors (app might be updated)
 	if updatedApp != nil {
 		runtime.SetFromResponse(updatedApp, ctx, &diags)
+
+		// Apply the union of provider default_tags and the resource tags.
+		resources.SyncTags(ctx, resource, resources.ApplicationTags, runtime.ID.ValueString(), runtime.Tags, &runtime.Tags, &runtime.TagsAll, &diags)
 	}
 
 	return diags

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
@@ -94,7 +95,7 @@ func (r *ResourceV) Update(ctx context.Context, req resource.UpdateRequest, res 
 }
 
 func (r *ResourceV) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
 		return
 	}
 
@@ -104,4 +105,9 @@ func (r *ResourceV) ModifyPlan(ctx context.Context, req resource.ModifyPlanReque
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "v", plan.Runtime, &res.Diagnostics)
+
+	// Recompute tags_all (provider default_tags merged with resource tags) so a
+	// provider-level default_tags change propagates to existing applications.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
 }

--- a/pkg/resources/application/v/v_test.go
+++ b/pkg/resources/application/v/v_test.go
@@ -28,7 +28,8 @@ func TestAccV_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-test-v-2")
 	fullName := fmt.Sprintf("clevercloud_v.%s", rName)
 	fullName2 := fmt.Sprintf("clevercloud_v.%s", rName2)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	vBlock := helper.NewRessource(
 		"clevercloud_v",
 		rName,
@@ -47,6 +48,7 @@ func TestAccV_basic(t *testing.T) {
 			"dependencies":       []string{},
 			"binary":             "a.out",
 			"development_build":  true,
+			"tags":               []string{"foo", "bar"},
 		}),
 	)
 	vBlock2 := helper.NewRessource(
@@ -76,6 +78,15 @@ func TestAccV_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deploy_url"), knownvalue.StringRegexp(regexp.MustCompile(`^git\+ssh.*\.git$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("region"), knownvalue.StringExact("par")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("build_flavor"), knownvalue.StringExact("XL")),
 				tests.NewCheckRemoteResource(fullName, func(ctx context.Context, id string) (*tmp.AppResponse, error) {
 					appRes := tmp.GetApp(ctx, cc, tests.ORGANISATION, id)

--- a/pkg/resources/configprovider/configprovider_test.go
+++ b/pkg/resources/configprovider/configprovider_test.go
@@ -26,11 +26,12 @@ func TestAccConfigProvider_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-cp")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_configprovider.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	configProviderBlock := helper.NewRessource(
 		"clevercloud_configprovider",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "environment": map[string]any{"foo": "this is foo"}}),
+		helper.SetKeyValues(map[string]any{"name": rName, "environment": map[string]any{"foo": "this is foo"}, "tags": []string{"foo", "bar"}}),
 	)
 
 	retrieveConfigProvider := func(ctx context.Context, id string) (*tmp.ConfigProvider, error) {
@@ -76,6 +77,15 @@ func TestAccConfigProvider_basic(t *testing.T) {
 
 					return nil
 				}),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/configprovider/crud.go
+++ b/pkg/resources/configprovider/crud.go
@@ -8,8 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceConfigProvider) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[ConfigProvider](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceConfigProvider) Create(ctx context.Context, req resource.CreateRequest, res *resource.CreateResponse) {
@@ -73,6 +91,8 @@ func (r *ResourceConfigProvider) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, addonConfigProvider.Tags, &addonConfigProvider.Tags, &addonConfigProvider.TagsAll, &res.Diagnostics)
+
 	res.Diagnostics.Append(res.State.Set(ctx, addonConfigProvider)...)
 }
 
@@ -106,6 +126,12 @@ func (r *ResourceConfigProvider) Read(ctx context.Context, req resource.ReadRequ
 	addonConfigProvider.fromEnv(ctx, envVars, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), addonConfigProvider.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		addonConfigProvider.Tags, addonConfigProvider.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonID, addonConfigProvider.Tags, &resp.Diagnostics)
 	}
 
 	// Update the state
@@ -167,6 +193,8 @@ func (r *ResourceConfigProvider) Update(ctx context.Context, req resource.Update
 		return
 	}
 	state.Environment = m
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/configprovider/schema.go
+++ b/pkg/resources/configprovider/schema.go
@@ -18,6 +18,8 @@ type ConfigProvider struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	Environment types.Map    `tfsdk:"environment"`
+	Tags        types.Set    `tfsdk:"tags"`
+	TagsAll     types.Set    `tfsdk:"tags_all"`
 }
 
 //go:embed doc.md
@@ -37,6 +39,16 @@ func (r ResourceConfigProvider) Schema(_ context.Context, req resource.SchemaReq
 			},
 			"id":   schema.StringAttribute{Computed: true, MarkdownDescription: "Generated unique identifier", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"name": schema.StringAttribute{Required: true, MarkdownDescription: "Name of the service"},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 		},
 	}
 }

--- a/pkg/resources/database/cellar/cellar_test.go
+++ b/pkg/resources/database/cellar/cellar_test.go
@@ -28,6 +28,7 @@ func TestAccCellar_basic(t *testing.T) {
 		helper.SetKeyValues(map[string]any{
 			"name":   rName,
 			"region": "par",
+			"tags":   []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -42,16 +43,91 @@ func TestAccCellar_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*\.services.clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("key_id"), knownvalue.StringRegexp(regexp.MustCompile(`^[A-Z0-9]{20}$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("key_secret"), knownvalue.StringRegexp(regexp.MustCompile(`^[a-zA-Z0-9]+$`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
 			},
 		}, {
 			ResourceName: "cellar_" + rName,
-			Config:       providerBlock.Append(cellarBlock.SetOneValue("name", rNameEdited)).String(),
+			Config: providerBlock.Append(
+				cellarBlock.SetOneValue("name", rNameEdited).SetOneValue("tags", []string{"bar", "baz"}),
+			).String(),
 			ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rNameEdited)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^cellar_.*`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*\.services.clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("key_id"), knownvalue.StringRegexp(regexp.MustCompile(`^[A-Z0-9]{20}$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("key_secret"), knownvalue.StringRegexp(regexp.MustCompile(`^[a-zA-Z0-9]+$`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("baz"),
+				})),
+			},
+		}},
+		CheckDestroy: tests.CheckDestroy(ctx),
+	})
+}
+
+// TestAccCellar_DefaultTags verifies that provider-level default_tags are merged into
+// tags_all (without polluting the resource-level tags attribute), and that changing
+// default_tags propagates to an existing resource via an in-place update.
+func TestAccCellar_DefaultTags(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-cellar-tags")
+	fullName := fmt.Sprintf("clevercloud_cellar.%s", rName)
+
+	cellarBlock := helper.NewRessource(
+		"clevercloud_cellar",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name": rName,
+			"tags": []string{"foo", "bar"},
+		}))
+
+	// config builds the provider block with the given default_tags plus the cellar.
+	config := func(defaultTags []string) string {
+		return helper.NewProvider("clevercloud").
+			SetOrganisation(tests.ORGANISATION).
+			SetKeyValues(map[string]any{"default_tags": defaultTags}).
+			Append(cellarBlock).
+			String()
+	}
+
+	// resource-level tags never change across steps: provider tags must not leak in.
+	resourceTags := knownvalue.SetExact([]knownvalue.Check{
+		knownvalue.StringExact("bar"),
+		knownvalue.StringExact("foo"),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 tests.ExpectOrganisation(t),
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		Steps: []resource.TestStep{{
+			// Merge: default_tags ∪ resource tags = tags_all.
+			ResourceName: "cellar_" + rName,
+			Config:       config([]string{"default"}),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), resourceTags),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("default"),
+					knownvalue.StringExact("foo"),
+				})),
+			},
+		}, {
+			// Propagation: adding a provider tag updates tags_all in place, tags unchanged.
+			ResourceName: "cellar_" + rName,
+			Config:       config([]string{"default", "platform"}),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), resourceTags),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("default"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("platform"),
+				})),
 			},
 		}},
 		CheckDestroy: tests.CheckDestroy(ctx),

--- a/pkg/resources/database/cellar/crud.go
+++ b/pkg/resources/database/cellar/crud.go
@@ -7,9 +7,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/s3"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time. This is what makes a provider-level tag change produce
+// a diff on existing resources so it propagates on the next apply.
+func (r *ResourceCellar) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return // resource is being destroyed, or provider not configured (e.g. validate)
+	}
+
+	plan := helper.PlanFrom[Cellar](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceCellar) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -54,6 +72,11 @@ func (r *ResourceCellar) Create(ctx context.Context, req resource.CreateRequest,
 
 	cellar.ID = pkg.FromStr(addonRes.RealID)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.ID, cellar.Tags, &cellar.Tags, &cellar.TagsAll, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	envRes := tmp.GetAddonEnv(ctx, r.Client(), r.Organization(), addonRes.RealID)
 	if envRes.HasError() {
 		resp.Diagnostics.AddError("failed to get add-on env vars", envRes.Error().Error())
@@ -92,7 +115,7 @@ func (r *ResourceCellar) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.Diagnostics.AddError("failed to get Cellar", addonRes.Error().Error())
 		return
 	}
-	addon := addonRes.Payload()
+	addonPayload := addonRes.Payload()
 
 	addonEnvRes := tmp.GetAddonEnv(ctx, r.Client(), r.Organization(), cellar.ID.ValueString())
 	if addonEnvRes.HasError() {
@@ -102,11 +125,13 @@ func (r *ResourceCellar) Read(ctx context.Context, req resource.ReadRequest, res
 	addonEnv := addonEnvRes.Payload()
 
 	creds := s3.FromEnvVars(*addonEnv)
-	cellar.Name = pkg.FromStr(addon.Name)
-	cellar.Region = pkg.FromStr(addon.Region)
+	cellar.Name = pkg.FromStr(addonPayload.Name)
+	cellar.Region = pkg.FromStr(addonPayload.Region)
 	cellar.Host = pkg.FromStr(creds.Host)
 	cellar.KeyID = pkg.FromStr(creds.KeyID)
 	cellar.KeySecret = pkg.FromStr(creds.KeySecret)
+
+	cellar.Tags, cellar.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonPayload.ID, cellar.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, cellar)...)
 }
@@ -137,6 +162,11 @@ func (r *ResourceCellar) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/cellar/schema.go
+++ b/pkg/resources/database/cellar/schema.go
@@ -15,8 +15,10 @@ import (
 type Cellar struct {
 	ID types.String `tfsdk:"id"`
 
-	Name   types.String `tfsdk:"name"`
-	Region types.String `tfsdk:"region"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 
 	Host      types.String `tfsdk:"host"`
 	KeyID     types.String `tfsdk:"key_id"`
@@ -41,6 +43,16 @@ func (r ResourceCellar) Schema(_ context.Context, req resource.SchemaRequest, re
 				Computed:            true,
 				MarkdownDescription: "Geographical region where the data will be stored",
 				Default:             stringdefault.StaticString("par"),
+			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the Cellar",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the Cellar: the resource `tags` merged with the provider-level `default_tags`",
 			},
 
 			// provider

--- a/pkg/resources/database/elasticsearch/crud.go
+++ b/pkg/resources/database/elasticsearch/crud.go
@@ -94,6 +94,8 @@ func (r *ResourceElasticsearch) Create(ctx context.Context, req resource.CreateR
 		&res.Diagnostics,
 	)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, plan.Tags, &plan.Tags, &plan.TagsAll, &res.Diagnostics)
+
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
 }
 
@@ -124,6 +126,8 @@ func (r *ResourceElasticsearch) Read(ctx context.Context, req resource.ReadReque
 		} else {
 			r.readFromAPI(&state, *elasticRes.Payload(), &res.Diagnostics)
 		}
+
+		state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonId, state.Tags, &res.Diagnostics)
 	}
 
 	state.Networkgroups = resources.ReadNetworkGroups(ctx, r, state.ID.ValueString(), &res.Diagnostics)
@@ -239,6 +243,12 @@ func (r *ResourceElasticsearch) Update(ctx context.Context, req resource.UpdateR
 		&state.Networkgroups,
 		&res.Diagnostics,
 	)
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString()); err != nil {
+		res.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &res.Diagnostics)
+	}
 
 	res.Diagnostics.Append(res.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/elasticsearch/elasticsearch_test.go
+++ b/pkg/resources/database/elasticsearch/elasticsearch_test.go
@@ -83,6 +83,46 @@ func TestAccElasticsearch_basic(t *testing.T) {
 	})
 }
 
+// TestAccElasticsearch_Tags verifies the resource `tags` and the merge into `tags_all`
+// with a provider-level default_tags.
+func TestAccElasticsearch_Tags(t *testing.T) {
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-es-tags")
+	fullName := fmt.Sprintf("clevercloud_elasticsearch.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
+	esBlock := helper.NewRessource(
+		"clevercloud_elasticsearch",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"plan":   "xs",
+			"tags":   []string{"foo", "bar"},
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(esBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
+			},
+		}},
+	})
+}
+
 // Issue #338: Test that version handling works correctly
 // The version field accepts only major version numbers (e.g., "8").
 // The API may return "8" or "8.19.9" but we always extract and store the major version.

--- a/pkg/resources/database/elasticsearch/schema.go
+++ b/pkg/resources/database/elasticsearch/schema.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/miton18/helper/set"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
@@ -30,6 +31,8 @@ type Elasticsearch struct {
 	Plan          types.String `tfsdk:"plan"`
 	Region        types.String `tfsdk:"region"`
 	Networkgroups types.Set    `tfsdk:"networkgroups"`
+	Tags          types.Set    `tfsdk:"tags"`
+	TagsAll       types.Set    `tfsdk:"tags_all"`
 
 	Version    types.String `tfsdk:"version"`
 	Encryption types.Bool   `tfsdk:"encryption"`
@@ -66,6 +69,16 @@ func (r *ResourceElasticsearch) Schema(_ context.Context, req resource.SchemaReq
 			},
 			"name": schema.StringAttribute{Required: true, MarkdownDescription: "Name of the elasticsearch"},
 			"plan": schema.StringAttribute{Required: true, MarkdownDescription: "Database size and spec"},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 			"region": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -153,13 +166,23 @@ func (r *ResourceElasticsearch) Schema(_ context.Context, req resource.SchemaReq
 }
 
 func (r *ResourceElasticsearch) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() { // Skip validation when deleting
+	if req.Plan.Raw.IsNull() || r.Provider == nil { // Skip validation when deleting
 		return
 	}
 
 	plan := helper.From[Elasticsearch](ctx, req.Plan, &res.Diagnostics)
 	if res.Diagnostics.HasError() {
 		return
+	}
+
+	// Recompute the effective tags_all (provider defaults merged with the resource tags)
+	// so a provider-level default_tags change propagates to existing resources.
+	if r.Provider != nil {
+		plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !plan.Version.IsNull() && !plan.Version.IsUnknown() {

--- a/pkg/resources/database/fsbucket/crud.go
+++ b/pkg/resources/database/fsbucket/crud.go
@@ -8,8 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceFSBucket) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[FSBucket](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceFSBucket) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -69,6 +87,8 @@ func (r *ResourceFSBucket) Create(ctx context.Context, req resource.CreateReques
 	fsbucket.FTPUsername = envMap["BUCKET_FTP_USERNAME"]
 	fsbucket.FTPPassword = envMap["BUCKET_FTP_PASSWORD"]
 
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.ID, fsbucket.Tags, &fsbucket.Tags, &fsbucket.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, fsbucket)...)
 }
 
@@ -95,7 +115,7 @@ func (r *ResourceFSBucket) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.AddError("failed to get FSBucket", addonRes.Error().Error())
 		return
 	}
-	addon := addonRes.Payload()
+	addonPayload := addonRes.Payload()
 
 	addonEnvRes := tmp.GetAddonEnv(ctx, r.Client(), r.Organization(), fsbucket.ID.ValueString())
 	if addonEnvRes.HasError() {
@@ -108,11 +128,13 @@ func (r *ResourceFSBucket) Read(ctx context.Context, req resource.ReadRequest, r
 		return m
 	})
 
-	fsbucket.Name = pkg.FromStr(addon.Name)
-	fsbucket.Region = pkg.FromStr(addon.Region)
+	fsbucket.Name = pkg.FromStr(addonPayload.Name)
+	fsbucket.Region = pkg.FromStr(addonPayload.Region)
 	fsbucket.Host = addonMap["BUCKET_HOST"]
 	fsbucket.FTPUsername = addonMap["BUCKET_FTP_USERNAME"]
 	fsbucket.FTPPassword = addonMap["BUCKET_FTP_PASSWORD"]
+
+	fsbucket.Tags, fsbucket.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonPayload.ID, fsbucket.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, fsbucket)...)
 }
@@ -143,6 +165,8 @@ func (r *ResourceFSBucket) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/fsbucket/fsbucket_test.go
+++ b/pkg/resources/database/fsbucket/fsbucket_test.go
@@ -21,11 +21,12 @@ func TestAccFSBucket_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-fsbucket")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_fsbucket.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	fsbucketBlock := helper.NewRessource(
 		"clevercloud_fsbucket",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}),
+		helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -40,6 +41,15 @@ func TestAccFSBucket_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*fsbucket.services.clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("ftp_username"), knownvalue.NotNull()),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("ftp_password"), knownvalue.NotNull()),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: "fsbucket_" + rName,

--- a/pkg/resources/database/fsbucket/schema.go
+++ b/pkg/resources/database/fsbucket/schema.go
@@ -15,8 +15,10 @@ import (
 type FSBucket struct {
 	ID types.String `tfsdk:"id"`
 
-	Name   types.String `tfsdk:"name"`
-	Region types.String `tfsdk:"region"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 
 	Host        types.String `tfsdk:"host"`
 	FTPUsername types.String `tfsdk:"ftp_username"`
@@ -41,6 +43,16 @@ func (r ResourceFSBucket) Schema(_ context.Context, req resource.SchemaRequest, 
 				Computed:            true,
 				MarkdownDescription: "Geographical region where the data will be stored",
 				Default:             stringdefault.StaticString("par"),
+			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
 			},
 
 			// provider

--- a/pkg/resources/database/materiakv/crud.go
+++ b/pkg/resources/database/materiakv/crud.go
@@ -10,8 +10,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceMateriaKV) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[MateriaKV](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceMateriaKV) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -72,6 +90,8 @@ func (r *ResourceMateriaKV) Create(ctx context.Context, req resource.CreateReque
 	kv.Port = pkg.FromI(int64(kvInfo.Port))
 	kv.Token = pkg.FromStr(kvInfo.Token)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, res.Payload().ID, kv.Tags, &kv.Tags, &kv.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, kv)...)
 }
 
@@ -122,6 +142,12 @@ func (r *ResourceMateriaKV) Read(ctx context.Context, req resource.ReadRequest, 
 	kv.Port = pkg.FromI(int64(addonKV.Port))
 	kv.Token = pkg.FromStr(addonKV.Token)
 
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), kv.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		kv.Tags, kv.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonID, kv.Tags, &resp.Diagnostics)
+	}
+
 	diags = resp.State.Set(ctx, kv)
 	resp.Diagnostics.Append(diags...)
 }
@@ -145,6 +171,9 @@ func (r *ResourceMateriaKV) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/pkg/resources/database/materiakv/materiakv_test.go
+++ b/pkg/resources/database/materiakv/materiakv_test.go
@@ -21,8 +21,9 @@ func TestAccMateriaKV_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-kv")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_materia_kv.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
-	materiakvBlock := helper.NewRessource("clevercloud_materia_kv", rName, helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}))
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
+	materiakvBlock := helper.NewRessource("clevercloud_materia_kv", rName, helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tests.ProtoV6Provider,
@@ -37,6 +38,15 @@ func TestAccMateriaKV_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("port"), knownvalue.NotNull()),
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("token")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,
@@ -47,6 +57,76 @@ func TestAccMateriaKV_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("port"), knownvalue.NotNull()),
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("token")),
+			},
+		}},
+	})
+}
+
+// TestAccMateriaKV_tagsPropagation covers the default_tags lifecycle on an existing
+// resource: a provider-level default_tags change must propagate to tags_all without
+// touching the resource-level tags, and removing a resource-level tag must remove it
+// from the API set.
+func TestAccMateriaKV_tagsPropagation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-kv-tags")
+	fullName := fmt.Sprintf("clevercloud_materia_kv.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
+	kvBlock := helper.NewRessource("clevercloud_materia_kv", rName, helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			// Create with default_tags ["managed"] and resource tags ["foo", "bar"].
+			ResourceName: rName,
+			Config:       providerBlock.Append(kvBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
+			},
+		}, {
+			// Change ONLY the provider default_tags: the new default must propagate to
+			// tags_all on the existing resource while the resource-level tags stay untouched.
+			ResourceName: rName,
+			Config: providerBlock.
+				SetKeyValues(map[string]any{"default_tags": []string{"managed", "cost-center"}}).
+				Append(kvBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("cost-center"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
+			},
+		}, {
+			// Drop a resource-level tag: it must be removed from the API set while the
+			// provider defaults are preserved.
+			ResourceName: rName,
+			Config:       providerBlock.Append(kvBlock.SetOneValue("tags", []string{"foo"})).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("cost-center"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}},
 	})

--- a/pkg/resources/database/materiakv/schema.go
+++ b/pkg/resources/database/materiakv/schema.go
@@ -18,6 +18,8 @@ type MateriaKV struct {
 	Port         types.Int64  `tfsdk:"port"`
 	Region       types.String `tfsdk:"region"`
 	Token        types.String `tfsdk:"token"`
+	Tags         types.Set    `tfsdk:"tags"`
+	TagsAll      types.Set    `tfsdk:"tags_all"`
 }
 
 //go:embed doc.md
@@ -35,6 +37,16 @@ func (r ResourceMateriaKV) Schema(_ context.Context, req resource.SchemaRequest,
 				Computed:            true,
 				Default:             stringdefault.StaticString("par"),
 				MarkdownDescription: "Geographical region where the data will be stored",
+			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
 			},
 			// provider
 			"id":            schema.StringAttribute{Computed: true, MarkdownDescription: "Generated unique identifier"},

--- a/pkg/resources/database/mongodb/crud.go
+++ b/pkg/resources/database/mongodb/crud.go
@@ -14,6 +14,23 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
 
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceMongoDB) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[MongoDB](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
+
 // Create a new resource
 func (r *ResourceMongoDB) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	mg := helper.PlanFrom[MongoDB](ctx, req.Plan, &resp.Diagnostics)
@@ -101,6 +118,8 @@ func (r *ResourceMongoDB) Create(ctx context.Context, req resource.CreateRequest
 		&resp.Diagnostics,
 	)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, res.Payload().ID, mg.Tags, &mg.Tags, &mg.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, mg)...)
 }
 
@@ -171,6 +190,7 @@ func (r *ResourceMongoDB) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	mg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonId, &resp.Diagnostics)
+	mg.Tags, mg.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonId, mg.Tags, &resp.Diagnostics)
 
 	diags := resp.State.Set(ctx, mg)
 	resp.Diagnostics.Append(diags...)
@@ -211,6 +231,8 @@ func (r *ResourceMongoDB) Update(ctx context.Context, req resource.UpdateRequest
 		&state.Networkgroups,
 		&resp.Diagnostics,
 	)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/mongodb/mongodb_test.go
+++ b/pkg/resources/database/mongodb/mongodb_test.go
@@ -24,8 +24,9 @@ func TestAccMongoDB_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-mg")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_mongodb.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
-	mongodbBlock := helper.NewRessource("clevercloud_mongodb", rName, helper.SetKeyValues(map[string]any{"name": rName, "plan": "xs_med", "region": "par"}))
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
+	mongodbBlock := helper.NewRessource("clevercloud_mongodb", rName, helper.SetKeyValues(map[string]any{"name": rName, "plan": "xs_med", "region": "par", "tags": []string{"foo", "bar"}}))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tests.ProtoV6Provider,
@@ -42,6 +43,15 @@ func TestAccMongoDB_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("user"), knownvalue.StringRegexp(regexp.MustCompile(`^[a-zA-Z0-9]+$`))),
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("password")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("database"), knownvalue.StringRegexp(regexp.MustCompile(`^[a-zA-Z0-9]+$`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/database/mysql/crud.go
+++ b/pkg/resources/database/mysql/crud.go
@@ -125,6 +125,8 @@ func (r *ResourceMySQL) Create(ctx context.Context, req resource.CreateRequest, 
 		&resp.Diagnostics,
 	)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, createdMy.ID, my.Tags, &my.Tags, &my.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, my)...)
 }
 
@@ -183,6 +185,7 @@ func (r *ResourceMySQL) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	my.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonId, &resp.Diagnostics)
+	my.Tags, my.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonId, my.Tags, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, my)...)
 }
 
@@ -259,6 +262,8 @@ func (r *ResourceMySQL) Update(ctx context.Context, req resource.UpdateRequest, 
 		&state.Networkgroups,
 		&resp.Diagnostics,
 	)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/mysql/mysql.go
+++ b/pkg/resources/database/mysql/mysql.go
@@ -34,7 +34,7 @@ func (r *ResourceMySQL) Metadata(ctx context.Context, req resource.MetadataReque
 
 // ModifyPlan validates that encryption, backup, skip_log_bin, and direct_host_only options are only used with dedicated plans
 func (r *ResourceMySQL) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() { // Skip validation when deleting
+	if req.Plan.Raw.IsNull() || r.Provider == nil { // Skip validation when deleting
 		return
 	}
 
@@ -45,6 +45,14 @@ func (r *ResourceMySQL) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 
 	// Skip validation if provider not configured yet
 	if r.Client() == nil {
+		return
+	}
+
+	// Recompute the effective tags_all (provider defaults merged with the resource tags)
+	// so a provider-level default_tags change propagates to existing resources.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	if res.Diagnostics.HasError() {
 		return
 	}
 

--- a/pkg/resources/database/mysql/mysql_test.go
+++ b/pkg/resources/database/mysql/mysql_test.go
@@ -28,7 +28,8 @@ func TestAccMySQL_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-test2-my")
 	fullName := fmt.Sprintf("clevercloud_mysql.%s", rName)
 	fullName2 := fmt.Sprintf("clevercloud_mysql.%s", rName2)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	mysqlBlock := helper.NewRessource(
 		"clevercloud_mysql",
 		rName,
@@ -37,6 +38,7 @@ func TestAccMySQL_basic(t *testing.T) {
 			"region": "par",
 			"plan":   "dev",
 			"backup": true,
+			"tags":   []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -55,6 +57,17 @@ func TestAccMySQL_basic(t *testing.T) {
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("password")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("plan"), knownvalue.StringExact("dev")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("backup"), knownvalue.Bool(true)),
+				// resource-level tags exclude the provider default_tags
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				// tags_all merges resource tags with provider default_tags
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,
@@ -282,9 +295,9 @@ func TestAccMySQL_Import(t *testing.T) {
 					addonID = res.Payload().ID
 					realID = res.Payload().RealID
 				},
-				Config:       providerBlock.Append(mysqlBlock).String(),
-				ResourceName: fullName,
-				ImportState:  true,
+				Config:             providerBlock.Append(mysqlBlock).String(),
+				ResourceName:       fullName,
+				ImportState:        true,
 				ImportStatePersist: true,
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return realID, nil

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -243,6 +243,8 @@ func (r *ResourcePostgreSQL) Create(ctx context.Context, req resource.CreateRequ
 		&resp.Diagnostics,
 	)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, createdPg.ID, pg.Tags, &pg.Tags, &pg.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, pg)...)
 }
 
@@ -338,6 +340,7 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	pg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonID, &resp.Diagnostics)
+	pg.Tags, pg.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonID, pg.Tags, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, pg)...)
 }
 
@@ -375,6 +378,13 @@ func (r *ResourcePostgreSQL) Update(ctx context.Context, req resource.UpdateRequ
 		&state.Networkgroups,
 		&resp.Diagnostics,
 	)
+
+	addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+		return
+	}
+	resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	// Handle plan, region, or version changes via migration

--- a/pkg/resources/database/postgresql/postgresql.go
+++ b/pkg/resources/database/postgresql/postgresql.go
@@ -127,7 +127,7 @@ func (r *ResourcePostgreSQL) UpgradeState(ctx context.Context) map[int64]resourc
 func (r *ResourcePostgreSQL) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
 	tflog.Debug(ctx, "ModifyPlan called for PostgreSQL")
 
-	if req.Plan.Raw.IsNull() { // Skip validation when deleting
+	if req.Plan.Raw.IsNull() || r.Provider == nil { // Skip validation when deleting
 		return
 	}
 
@@ -139,6 +139,15 @@ func (r *ResourcePostgreSQL) ModifyPlan(ctx context.Context, req resource.Modify
 	// Skip validation if provider not configured yet
 	if r.Client() == nil {
 		tflog.Debug(ctx, "Skipping validation - provider not configured")
+		return
+	}
+
+	// Recompute the effective tags_all (provider defaults merged with the resource tags).
+	// Doing this at plan time is what makes a provider-level tag change produce a diff on
+	// existing resources so it propagates on the next apply.
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+	res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+	if res.Diagnostics.HasError() {
 		return
 	}
 

--- a/pkg/resources/database/postgresql/postgresql_test.go
+++ b/pkg/resources/database/postgresql/postgresql_test.go
@@ -36,6 +36,7 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 			"region": "par",
 			"plan":   "dev",
 			"backup": true,
+			"tags":   []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -54,12 +55,22 @@ func TestAccPostgreSQL_basic(t *testing.T) {
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("password")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("plan"), knownvalue.StringExact("dev")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("backup"), knownvalue.Bool(true)),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
 			},
 		}, {
 			ResourceName: rName,
-			Config:       providerBlock.Append(postgresqlBlock.SetOneValue("name", rNameEdited)).String(),
+			Config: providerBlock.Append(
+				postgresqlBlock.SetOneValue("name", rNameEdited).SetOneValue("tags", []string{"bar", "baz"}),
+			).String(),
 			ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rNameEdited)),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("baz"),
+				})),
 			},
 		}, {
 			ResourceName: rName2,

--- a/pkg/resources/database/pulsar/crud.go
+++ b/pkg/resources/database/pulsar/crud.go
@@ -10,8 +10,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourcePulsar) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Pulsar](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourcePulsar) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -48,13 +66,15 @@ func (r *ResourcePulsar) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("failed to create add-on", res.Error().Error())
 		return
 	}
-	addon := res.Payload()
+	createdAddon := res.Payload()
 
-	plan.ID = pkg.FromStr(addon.RealID)
+	plan.ID = pkg.FromStr(createdAddon.RealID)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 
-	pulsarRes := tmp.GetPulsar(ctx, r.Client(), r.Organization(), addon.RealID)
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, plan.Tags, &plan.Tags, &plan.TagsAll, &resp.Diagnostics)
+
+	pulsarRes := tmp.GetPulsar(ctx, r.Client(), r.Organization(), createdAddon.RealID)
 	if pulsarRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Pulsar", pulsarRes.Error().Error())
 		return
@@ -115,8 +135,10 @@ func (r *ResourcePulsar) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.Diagnostics.AddError("failed to get add-on", addonRes.Error().Error())
 		return
 	}
-	addon := addonRes.Payload()
-	readOldAddon(&state, addon, &resp.Diagnostics)
+	addonPayload := addonRes.Payload()
+	readOldAddon(&state, addonPayload, &resp.Diagnostics)
+
+	state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonPayload.ID, state.Tags, &resp.Diagnostics)
 
 	readRetention(ctx, &state, &resp.Diagnostics)
 
@@ -244,6 +266,12 @@ func (r *ResourcePulsar) Update(ctx context.Context, req resource.UpdateRequest,
 	} else {
 		state.Name = pkg.FromStr(addonRes.Payload().Name)
 		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	}
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 	}
 
 	state.RetentionPeriod = plan.RetentionPeriod

--- a/pkg/resources/database/pulsar/pulsar_test.go
+++ b/pkg/resources/database/pulsar/pulsar_test.go
@@ -21,11 +21,12 @@ func TestAccPulsar_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-pulsar")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_pulsar.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	pulsarBlock := helper.NewRessource(
 		"clevercloud_pulsar",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}),
+		helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -44,6 +45,15 @@ func TestAccPulsar_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tenant"), knownvalue.StringExact(tests.ORGANISATION)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("namespace"), knownvalue.NotNull()),
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("token")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/database/pulsar/schema.go
+++ b/pkg/resources/database/pulsar/schema.go
@@ -17,8 +17,10 @@ import (
 type Pulsar struct {
 	ID types.String `tfsdk:"id"`
 
-	Name   types.String `tfsdk:"name"`
-	Region types.String `tfsdk:"region"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 
 	BinaryURL types.String `tfsdk:"binary_url"`
 	HTTPUrl   types.String `tfsdk:"http_url"`
@@ -47,9 +49,19 @@ func (r ResourcePulsar) Schema(_ context.Context, req resource.SchemaRequest, re
 		Version:             0,
 		MarkdownDescription: resourcePulsarDoc,
 		Attributes: map[string]schema.Attribute{
-			"id":               schema.StringAttribute{Computed: true, MarkdownDescription: "Generated unique identifier", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-			"name":             schema.StringAttribute{Required: true, MarkdownDescription: "Name of the Pulsar"},
-			"region":           schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Geographical region where the data will be stored", Default: stringdefault.StaticString("par")},
+			"id":     schema.StringAttribute{Computed: true, MarkdownDescription: "Generated unique identifier", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":   schema.StringAttribute{Required: true, MarkdownDescription: "Name of the Pulsar"},
+			"region": schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Geographical region where the data will be stored", Default: stringdefault.StaticString("par")},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 			"binary_url":       schema.StringAttribute{Computed: true, MarkdownDescription: "Pulsar native protocol address"},
 			"http_url":         schema.StringAttribute{Computed: true, MarkdownDescription: "Pulsar REST API address"},
 			"tenant":           schema.StringAttribute{Computed: true, MarkdownDescription: "Pulsar tenant"},

--- a/pkg/resources/database/redis/crud.go
+++ b/pkg/resources/database/redis/crud.go
@@ -17,6 +17,23 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
 
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceRedis) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Redis](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
+
 // Create a new resource
 func (r *ResourceRedis) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	rd := helper.PlanFrom[Redis](ctx, req.Plan, &resp.Diagnostics)
@@ -87,6 +104,8 @@ func (r *ResourceRedis) Create(ctx context.Context, req resource.CreateRequest, 
 		&resp.Diagnostics,
 	)
 
+	resources.SyncTags(ctx, r, resources.AddonTags, res.Payload().ID, rd.Tags, &rd.Tags, &rd.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, rd)...)
 }
 
@@ -152,6 +171,7 @@ func (r *ResourceRedis) Read(ctx context.Context, req resource.ReadRequest, resp
 	rd.Token = envAsMap["REDIS_PASSWORD"]
 
 	rd.Networkgroups = resources.ReadNetworkGroups(ctx, r, rd.ID.ValueString(), &resp.Diagnostics)
+	rd.Tags, rd.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonRD.ID, rd.Tags, &resp.Diagnostics)
 
 	diags = resp.State.Set(ctx, rd)
 	resp.Diagnostics.Append(diags...)
@@ -192,6 +212,8 @@ func (r *ResourceRedis) Update(ctx context.Context, req resource.UpdateRequest, 
 		&state.Networkgroups,
 		&resp.Diagnostics,
 	)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/database/redis/redis_test.go
+++ b/pkg/resources/database/redis/redis_test.go
@@ -21,11 +21,13 @@ func TestAccRedis_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-redis")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_redis.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	materiakvBlock := helper.NewRessource("clevercloud_redis", rName, helper.SetKeyValues(map[string]any{
 		"name":   rName,
 		"region": "par",
 		"plan":   "m_mono",
+		"tags":   []string{"foo", "bar"},
 	}))
 
 	resource.Test(t, resource.TestCase{
@@ -41,6 +43,15 @@ func TestAccRedis_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*.services.clever-cloud.com$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("port"), knownvalue.NotNull()),
 				statecheck.ExpectSensitiveValue(fullName, tfjsonpath.New("token")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/networkgroup/crud.go
+++ b/pkg/resources/networkgroup/crud.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
@@ -14,12 +16,64 @@ import (
 	"go.clever-cloud.dev/sdk/models"
 )
 
+// defaultTagsFor returns the provider-level default tags to merge for this network group,
+// or nil when the resource opts out via ignore_default_tags.
+func (r *ResourceNG) defaultTagsFor(ng Networkgroup) []string {
+	if ng.IgnoreDefaultTags.ValueBool() {
+		return nil
+	}
+	return r.DefaultTags()
+}
+
+// ModifyPlan recomputes the effective tags_all (provider default_tags merged with the
+// resource tags, unless opted out). Network groups cannot be updated in place, so when the
+// effective set changes on an existing resource, replacement is forced to apply the new tags.
+func (r *ResourceNG) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return // resource is being destroyed, or provider not configured (e.g. validate)
+	}
+
+	plan := helper.PlanFrom[Networkgroup](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Can't compute the effective set until the resource tags are known.
+	if plan.Tags.IsUnknown() {
+		plan.TagsAll = basetypes.NewSetUnknown(types.StringType)
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+		return
+	}
+
+	merged := pkg.MergeTags(r.defaultTagsFor(plan), pkg.SetToStringSlice(ctx, plan.Tags, &resp.Diagnostics))
+	plan.TagsAll = pkg.FromSetString(merged, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		return // create: nothing to replace
+	}
+	state := helper.StateFrom[Networkgroup](ctx, req.State, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Guard on a non-null prior tags_all so upgrading state that predates this attribute
+	// (null tags_all) doesn't trigger a spurious replacement before the first refresh.
+	if !state.TagsAll.IsNull() && !state.TagsAll.Equal(plan.TagsAll) {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("tags_all"))
+	}
+}
+
 // readFromAPI updates the given state with values returned by the API.
 //
-// For optional fields (description, tags), the rule is:
-//   - state null + API empty → keep null (user never set it, nothing to sync)
-//   - otherwise              → sync from API (state was set, or API returned a value)
-func readFromAPI(state *Networkgroup, ng *models.NetworkGroup1, diags *diag.Diagnostics) {
+// tags_all reflects every tag on the network group. The resource-level `tags` attribute
+// excludes the provider-level default_tags so they don't leak into it (which would cause
+// a perpetual diff). For optional fields (description, tags), the rule is:
+//   - state null + nothing resource-level → keep null (user never set it, nothing to sync)
+//   - otherwise                           → sync from API
+func readFromAPI(state *Networkgroup, ng *models.NetworkGroup1, defaultTags []string, diags *diag.Diagnostics) {
 	if ng == nil || state == nil {
 		return
 	}
@@ -31,10 +85,9 @@ func readFromAPI(state *Networkgroup, ng *models.NetworkGroup1, diags *diag.Diag
 		state.Description = basetypes.NewStringPointerValue(ng.Description)
 	}
 
-	apiTagsEmpty := len(ng.Tags) == 0
-	if !state.Tags.IsNull() || !apiTagsEmpty {
-		state.Tags = pkg.FromSetString(ng.Tags, diags)
-	}
+	// tags_all is the full effective set (resource tags + provider default_tags);
+	// tags excludes the provider default_tags.
+	state.Tags, state.TagsAll = pkg.SplitTags(ng.Tags, defaultTags, state.Tags, diags)
 
 	state.Network = pkg.FromStr(ng.NetworkIP)
 }
@@ -51,6 +104,10 @@ func (r *ResourceNG) Create(ctx context.Context, req resource.CreateRequest, res
 
 	label := plan.Name.ValueString()
 	description := plan.Description.ValueString()
+	// Apply the union of the provider-level default_tags and the resource-level tags
+	// (unless the resource opts out via ignore_default_tags).
+	defaultTags := r.defaultTagsFor(plan)
+	mergedTags := pkg.MergeTags(defaultTags, pkg.SetToStringSlice(ctx, plan.Tags, &resp.Diagnostics))
 	ngRes := r.SDK.
 		V4().
 		Networkgroups().
@@ -61,7 +118,7 @@ func (r *ResourceNG) Create(ctx context.Context, req resource.CreateRequest, res
 			ID:          &id,
 			Label:       &label,
 			Description: &description,
-			Tags:        pkg.SetToStringSlice(ctx, plan.Tags, &resp.Diagnostics),
+			Tags:        mergedTags,
 		})
 	if ngRes.HasError() {
 		resp.Diagnostics.AddError("failed to create networkgroup", ngRes.Error().Error())
@@ -74,7 +131,7 @@ func (r *ResourceNG) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
-	readFromAPI(&plan, ng, &resp.Diagnostics)
+	readFromAPI(&plan, ng, defaultTags, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -106,7 +163,7 @@ func (r *ResourceNG) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	}
 	ng := ngRes.Payload()
 
-	readFromAPI(&state, ng, &resp.Diagnostics)
+	readFromAPI(&state, ng, r.defaultTagsFor(state), &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/pkg/resources/networkgroup/crud_test.go
+++ b/pkg/resources/networkgroup/crud_test.go
@@ -73,7 +73,7 @@ func TestReadFromAPI_Description(t *testing.T) {
 			}
 			var diags diag.Diagnostics
 
-			readFromAPI(state, ng, &diags)
+			readFromAPI(state, ng, nil, &diags)
 
 			if diags.HasError() {
 				t.Fatalf("unexpected diagnostics: %v", diags)
@@ -94,13 +94,40 @@ func TestReadFromAPI_Description(t *testing.T) {
 	}
 }
 
+func extractSet(t *testing.T, s basetypes.SetValue) []string {
+	t.Helper()
+	var got []string
+	if d := s.ElementsAs(t.Context(), &got, false); d.HasError() {
+		t.Fatalf("failed to extract set: %v", d)
+	}
+	return got
+}
+
+func assertSameElements(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	seen := map[string]bool{}
+	for _, v := range got {
+		seen[v] = true
+	}
+	for _, w := range want {
+		if !seen[w] {
+			t.Fatalf("missing %q in result %v", w, got)
+		}
+	}
+}
+
 func TestReadFromAPI_Tags(t *testing.T) {
 	cases := []struct {
-		name      string
-		stateTags basetypes.SetValue
-		apiTags   []string
-		wantNull  bool
-		wantTags  []string
+		name        string
+		stateTags   basetypes.SetValue
+		defaultTags []string
+		apiTags     []string
+		wantNull    bool
+		wantTags    []string
+		wantTagsAll []string
 	}{{
 		name:      "null state + nil API → keep null",
 		stateTags: setNull(),
@@ -112,20 +139,39 @@ func TestReadFromAPI_Tags(t *testing.T) {
 		apiTags:   []string{},
 		wantNull:  true,
 	}, {
-		name:      "null state + values API → sync from API",
-		stateTags: setNull(),
-		apiTags:   []string{"a", "b"},
-		wantTags:  []string{"a", "b"},
+		name:        "null state + values API → sync from API",
+		stateTags:   setNull(),
+		apiTags:     []string{"a", "b"},
+		wantTags:    []string{"a", "b"},
+		wantTagsAll: []string{"a", "b"},
 	}, {
-		name:      "set state + values API → sync from API",
-		stateTags: setOf(t, "old"),
-		apiTags:   []string{"new"},
-		wantTags:  []string{"new"},
+		name:        "set state + values API → sync from API",
+		stateTags:   setOf(t, "old"),
+		apiTags:     []string{"new"},
+		wantTags:    []string{"new"},
+		wantTagsAll: []string{"new"},
 	}, {
-		name:      "set state + empty API → sync to empty",
-		stateTags: setOf(t, "old"),
-		apiTags:   []string{},
-		wantTags:  []string{},
+		name:        "set state + empty API → sync to empty",
+		stateTags:   setOf(t, "old"),
+		apiTags:     []string{},
+		wantTags:    []string{},
+		wantTagsAll: []string{},
+	}, {
+		// provider default_tags are excluded from tags but kept in tags_all
+		name:        "null state + default merged into API → tags excludes default, tags_all keeps it",
+		stateTags:   setNull(),
+		defaultTags: []string{"managed"},
+		apiTags:     []string{"foo", "managed"},
+		wantTags:    []string{"foo"},
+		wantTagsAll: []string{"foo", "managed"},
+	}, {
+		// only a default tag on the API and user never set tags → tags stays null
+		name:        "null state + only default on API → keep tags null, tags_all has default",
+		stateTags:   setNull(),
+		defaultTags: []string{"managed"},
+		apiTags:     []string{"managed"},
+		wantNull:    true,
+		wantTagsAll: []string{"managed"},
 	}}
 
 	for _, tc := range cases {
@@ -138,11 +184,15 @@ func TestReadFromAPI_Tags(t *testing.T) {
 			}
 			var diags diag.Diagnostics
 
-			readFromAPI(state, ng, &diags)
+			readFromAPI(state, ng, tc.defaultTags, &diags)
 
 			if diags.HasError() {
 				t.Fatalf("unexpected diagnostics: %v", diags)
 			}
+
+			// tags_all always reflects the full API set.
+			assertSameElements(t, extractSet(t, state.TagsAll), tc.wantTagsAll)
+
 			if tc.wantNull {
 				if !state.Tags.IsNull() {
 					t.Fatalf("expected tags to be null, got %v", state.Tags)
@@ -152,25 +202,7 @@ func TestReadFromAPI_Tags(t *testing.T) {
 			if state.Tags.IsNull() {
 				t.Fatalf("expected tags %v, got null", tc.wantTags)
 			}
-
-			var got []string
-			diags2 := state.Tags.ElementsAs(t.Context(), &got, false)
-			if diags2.HasError() {
-				t.Fatalf("failed to extract tags: %v", diags2)
-			}
-			if len(got) != len(tc.wantTags) {
-				t.Fatalf("expected tags %v, got %v", tc.wantTags, got)
-			}
-			// Sets are unordered: check membership
-			seen := map[string]bool{}
-			for _, v := range got {
-				seen[v] = true
-			}
-			for _, want := range tc.wantTags {
-				if !seen[want] {
-					t.Fatalf("missing tag %q in result %v", want, got)
-				}
-			}
+			assertSameElements(t, extractSet(t, state.Tags), tc.wantTags)
 		})
 	}
 }
@@ -180,7 +212,7 @@ func TestReadFromAPI_RequiredFields(t *testing.T) {
 	ng := &models.NetworkGroup1{Label: "myng", NetworkIP: "10.42.0.0/16"}
 	var diags diag.Diagnostics
 
-	readFromAPI(state, ng, &diags)
+	readFromAPI(state, ng, nil, &diags)
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
@@ -196,6 +228,6 @@ func TestReadFromAPI_RequiredFields(t *testing.T) {
 func TestReadFromAPI_NilSafe(t *testing.T) {
 	var diags diag.Diagnostics
 	// Should not panic.
-	readFromAPI(nil, &models.NetworkGroup1{}, &diags)
-	readFromAPI(&Networkgroup{}, nil, &diags)
+	readFromAPI(nil, &models.NetworkGroup1{}, nil, &diags)
+	readFromAPI(&Networkgroup{}, nil, nil, &diags)
 }

--- a/pkg/resources/networkgroup/doc.md
+++ b/pkg/resources/networkgroup/doc.md
@@ -1,3 +1,5 @@
 Manage any [Network Group](https://www.clever.cloud/developers/doc/develop/network-groups/).
 
 See [Network Groups product specification](https://www.clever.cloud/developers/doc/develop/network-groups/).
+
+~> Network groups cannot be updated in place: any change to the effective tag set (the resource `tags`, or the provider-level `default_tags` unless `ignore_default_tags` is set) **replaces the network group**, dropping its members during recreation. Set `ignore_default_tags = true` to shield a network group from provider-level tag changes.

--- a/pkg/resources/networkgroup/ng_test.go
+++ b/pkg/resources/networkgroup/ng_test.go
@@ -21,7 +21,8 @@ func TestAccNG_basic(t *testing.T) {
 	ctx := t.Context()
 	rName := acctest.RandomWithPrefix("tf-test-ng")
 	fullName := fmt.Sprintf("clevercloud_networkgroup.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	addonBlock := helper.NewRessource(
 		"clevercloud_networkgroup",
 		rName,
@@ -46,6 +47,51 @@ func TestAccNG_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
 					knownvalue.StringExact("tag1"),
 					knownvalue.StringExact("tag2"),
+				})),
+				// tags_all merges the resource tags with the provider default_tags
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("managed"),
+					knownvalue.StringExact("tag1"),
+					knownvalue.StringExact("tag2"),
+				})),
+			},
+		}},
+	})
+}
+
+// TestAccNG_ignoreDefaultTags verifies that a network group with ignore_default_tags=true
+// does not merge the provider-level default_tags into its tags_all.
+func TestAccNG_ignoreDefaultTags(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-ng")
+	fullName := fmt.Sprintf("clevercloud_networkgroup.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
+	ngBlock := helper.NewRessource(
+		"clevercloud_networkgroup",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":                rName,
+			"tags":                []string{"tag1"},
+			"ignore_default_tags": true,
+		}),
+	)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: rName,
+			Config:       providerBlock.Append(ngBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("tag1"),
+				})),
+				// default_tags are ignored: "managed" must NOT appear in tags_all
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("tag1"),
 				})),
 			},
 		}},
@@ -75,8 +121,8 @@ func TestAccNG_withPeers(t *testing.T) {
 		"clevercloud_docker",
 		appName,
 		helper.SetKeyValues(map[string]any{
-			"name":               appName,
-			"region":             "par",
+			"name":   appName,
+			"region": "par",
 			// Boot a real instance so the NG actually registers a peer.
 			// Without a peer the API never returns the union-typed `peers` field
 			// and the SDK unmarshal bug stays hidden.

--- a/pkg/resources/networkgroup/schema.go
+++ b/pkg/resources/networkgroup/schema.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -15,11 +19,13 @@ import (
 )
 
 type Networkgroup struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Tags        types.Set    `tfsdk:"tags"`
-	Network     types.String `tfsdk:"network"`
+	ID                types.String `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Description       types.String `tfsdk:"description"`
+	Tags              types.Set    `tfsdk:"tags"`
+	TagsAll           types.Set    `tfsdk:"tags_all"`
+	IgnoreDefaultTags types.Bool   `tfsdk:"ignore_default_tags"`
+	Network           types.String `tfsdk:"network"`
 }
 
 //go:embed doc.md
@@ -36,8 +42,21 @@ func (r ResourceNG) Schema(_ context.Context, req resource.SchemaRequest, resp *
 				validateLabel,
 			}},
 			"description": schema.StringAttribute{Optional: true, MarkdownDescription: "Description of the network group"},
-			"tags":        schema.SetAttribute{ElementType: types.StringType, Optional: true, MarkdownDescription: "Tags of the network group"},
-			"network":     schema.StringAttribute{Computed: true, MarkdownDescription: "Network CIDR of the network group"},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the network group. Network groups cannot be updated in place, so changing tags replaces the resource.",
+				PlanModifiers:       []planmodifier.Set{setplanmodifier.RequiresReplace()},
+			},
+			"tags_all": schema.SetAttribute{ElementType: types.StringType, Computed: true, MarkdownDescription: "All tags applied to the network group: the resource `tags` merged with the provider-level `default_tags` (unless `ignore_default_tags` is set)"},
+			"ignore_default_tags": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "When true, the provider-level `default_tags` are not merged into this network group. Changing this replaces the resource.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+			},
+			"network": schema.StringAttribute{Computed: true, MarkdownDescription: "Network CIDR of the network group"},
 		},
 	}
 }

--- a/pkg/resources/software/keycloak/crud.go
+++ b/pkg/resources/software/keycloak/crud.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 	"go.clever-cloud.dev/sdk/models"
 )
@@ -50,19 +51,21 @@ func (r *ResourceKeycloak) Create(ctx context.Context, req resource.CreateReques
 		res.Diagnostics.AddError("failed to create Keycloak", createAddonRes.Error().Error())
 		return
 	}
-	addon := createAddonRes.Payload()
+	createdAddon := createAddonRes.Payload()
 
-	plan.ID = pkg.FromStr(addon.RealID)
-	plan.Region = pkg.FromStr(addon.Region)
+	plan.ID = pkg.FromStr(createdAddon.RealID)
+	plan.Region = pkg.FromStr(createdAddon.Region)
 
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, plan.Tags, &plan.Tags, &plan.TagsAll, &res.Diagnostics)
 
 	keycloakRes := r.SDK.
 		V4().
 		AddonProviders().
 		AddonKeycloak().
 		Addons().
-		Addonkeycloakid(addon.RealID).
+		Addonkeycloakid(createdAddon.RealID).
 		Getkeycloakwithoutownerid(ctx)
 	if keycloakRes.HasError() {
 		res.Diagnostics.AddError("failed to get Keycloak", keycloakRes.Error().Error())
@@ -99,9 +102,11 @@ func (r *ResourceKeycloak) Read(ctx context.Context, req resource.ReadRequest, r
 	} else if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Keycloak addon", addonRes.Error().Error())
 	} else {
-		addon := addonRes.Payload()
-		state.Name = pkg.FromStr(addon.Name)
-		state.Region = pkg.FromStr(addon.Region)
+		addonPayload := addonRes.Payload()
+		state.Name = pkg.FromStr(addonPayload.Name)
+		state.Region = pkg.FromStr(addonPayload.Region)
+
+		state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonPayload.ID, state.Tags, &resp.Diagnostics)
 	}
 
 	keycloakRes := r.SDK.
@@ -145,6 +150,12 @@ func (r *ResourceKeycloak) Update(ctx context.Context, req resource.UpdateReques
 		resp.Diagnostics.AddError("failed to update Keycloak", addonRes.Error().Error())
 	} else {
 		state.Name = pkg.FromStr(addonRes.Payload().Name)
+	}
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 	}
 
 	// Handle version upgrade

--- a/pkg/resources/software/keycloak/keycloak_test.go
+++ b/pkg/resources/software/keycloak/keycloak_test.go
@@ -23,11 +23,12 @@ func TestAccKeycloak_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-kc")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_keycloak.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	materiakvBlock := helper.NewRessource(
 		"clevercloud_keycloak",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}),
+		helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -43,6 +44,15 @@ func TestAccKeycloak_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*clever-cloud.com/admin$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("admin_username"), knownvalue.NotNull()),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("admin_password"), knownvalue.NotNull()),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/software/keycloak/schema.go
+++ b/pkg/resources/software/keycloak/schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 )
 
@@ -25,6 +26,8 @@ type Keycloak struct {
 	AdminUsername types.String `tfsdk:"admin_username"`
 	AdminPassword types.String `tfsdk:"admin_password"`
 	FSBucketID    types.String `tfsdk:"fsbucket_id"`
+	Tags          types.Set    `tfsdk:"tags"`
+	TagsAll       types.Set    `tfsdk:"tags_all"`
 }
 
 //go:embed doc.md
@@ -43,6 +46,16 @@ func (r ResourceKeycloak) Schema(_ context.Context, req resource.SchemaRequest, 
 				Default:             stringdefault.StaticString("par"),
 				MarkdownDescription: "Geographical region where the data will be stored",
 			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 			"access_domain":  schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Main domaine to access the instance"},
 			"version":        schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Keycloak official version"},
 			"host":           schema.StringAttribute{Computed: true, MarkdownDescription: "URL to access Keycloak"},
@@ -54,12 +67,22 @@ func (r ResourceKeycloak) Schema(_ context.Context, req resource.SchemaRequest, 
 }
 
 func (r ResourceKeycloak) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() { // plan is null when calling Delete() methode
+	if req.Plan.Raw.IsNull() || r.Provider == nil { // plan is null when calling Delete() methode
 		return
 	}
 	plan := helper.From[Keycloak](ctx, req.Plan, &res.Diagnostics)
 	if res.Diagnostics.HasError() {
 		return
+	}
+
+	// Recompute the effective tags_all (provider defaults merged with the resource tags)
+	// so a provider-level default_tags change propagates to existing resources.
+	if r.Provider != nil {
+		plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &res.Diagnostics)
+		res.Diagnostics.Append(res.Plan.Set(ctx, plan)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Skip validation if version is not specified

--- a/pkg/resources/software/matomo/crud.go
+++ b/pkg/resources/software/matomo/crud.go
@@ -7,8 +7,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceMatomo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Matomo](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceMatomo) Create(ctx context.Context, req resource.CreateRequest, res *resource.CreateResponse) {
@@ -44,13 +62,13 @@ func (r *ResourceMatomo) Create(ctx context.Context, req resource.CreateRequest,
 		res.Diagnostics.AddError("failed to create Matomo", createAddonRes.Error().Error())
 		return
 	}
-	addon := createAddonRes.Payload()
+	createdAddon := createAddonRes.Payload()
 
-	appMatomo.ID = pkg.FromStr(addon.RealID)
-	appMatomo.Region = pkg.FromStr(addon.Region)
+	appMatomo.ID = pkg.FromStr(createdAddon.RealID)
+	appMatomo.Region = pkg.FromStr(createdAddon.Region)
 	res.Diagnostics.Append(res.State.Set(ctx, appMatomo)...)
 
-	matomoRes := tmp.GetMatomo(ctx, r.Client(), addon.RealID)
+	matomoRes := tmp.GetMatomo(ctx, r.Client(), createdAddon.RealID)
 	if matomoRes.HasError() {
 		res.Diagnostics.AddError("cannot get matomo", matomoRes.Error().Error())
 	} else {
@@ -58,6 +76,8 @@ func (r *ResourceMatomo) Create(ctx context.Context, req resource.CreateRequest,
 		appMatomo.Host = pkg.FromStr(matomo.AccessURL)
 		appMatomo.Version = pkg.FromStr(matomo.Version)
 	}
+
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, appMatomo.Tags, &appMatomo.Tags, &appMatomo.TagsAll, &res.Diagnostics)
 
 	res.Diagnostics.Append(res.State.Set(ctx, appMatomo)...)
 }
@@ -94,9 +114,11 @@ func (r *ResourceMatomo) Read(ctx context.Context, req resource.ReadRequest, res
 	if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Matomo addon", addonRes.Error().Error())
 	} else {
-		addon := addonRes.Payload()
-		state.Region = pkg.FromStr(addon.Region)
+		addonPayload := addonRes.Payload()
+		state.Region = pkg.FromStr(addonPayload.Region)
 	}
+
+	state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonId, state.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -126,6 +148,12 @@ func (r *ResourceMatomo) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("failed to update Matomo", addonRes.Error().Error())
 	} else {
 		state.Name = pkg.FromStr(addonRes.Payload().Name)
+	}
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)

--- a/pkg/resources/software/matomo/matomo_test.go
+++ b/pkg/resources/software/matomo/matomo_test.go
@@ -20,11 +20,12 @@ func TestAccMatomo_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-matomo")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_matomo.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	materiakvBlock := helper.NewRessource(
 		"clevercloud_matomo",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}),
+		helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -38,6 +39,15 @@ func TestAccMatomo_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^matomo_.*`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("host"), knownvalue.StringRegexp(regexp.MustCompile(`^.*clever-cloud.com$`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/software/matomo/schema.go
+++ b/pkg/resources/software/matomo/schema.go
@@ -18,6 +18,8 @@ type Matomo struct {
 	Region  types.String `tfsdk:"region"`
 	Host    types.String `tfsdk:"host"`
 	Version types.String `tfsdk:"version"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 }
 
 //go:embed doc.md
@@ -38,6 +40,16 @@ func (r ResourceMatomo) Schema(_ context.Context, req resource.SchemaRequest, re
 				MarkdownDescription: "Geographical region where the data will be stored",
 			},
 			"version": schema.StringAttribute{Computed: true, MarkdownDescription: "Current version of Matomo"},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 		},
 	}
 }

--- a/pkg/resources/software/metabase/crud.go
+++ b/pkg/resources/software/metabase/crud.go
@@ -7,8 +7,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceMetabase) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Metabase](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 // Create a new resource
 func (r *ResourceMetabase) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -43,19 +61,21 @@ func (r *ResourceMetabase) Create(ctx context.Context, req resource.CreateReques
 		resp.Diagnostics.AddError("failed to create addon", res.Error().Error())
 		return
 	}
-	addon := res.Payload()
+	createdAddon := res.Payload()
 
-	mb.ID = pkg.FromStr(addon.RealID)
-	mb.Region = pkg.FromStr(addon.Region)
+	mb.ID = pkg.FromStr(createdAddon.RealID)
+	mb.Region = pkg.FromStr(createdAddon.Region)
 	resp.Diagnostics.Append(resp.State.Set(ctx, mb)...)
 
-	metabaseRes := tmp.GetMetabase(ctx, r.Client(), addon.RealID)
+	metabaseRes := tmp.GetMetabase(ctx, r.Client(), createdAddon.RealID)
 	if metabaseRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Metabase", metabaseRes.Error().Error())
 	} else {
 		metabase := metabaseRes.Payload()
 		mb.Host = pkg.FromStr(metabase.AccessURL)
 	}
+
+	resources.SyncTags(ctx, r, resources.AddonTags, createdAddon.ID, mb.Tags, &mb.Tags, &mb.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, mb)...)
 }
@@ -94,9 +114,11 @@ func (r *ResourceMetabase) Read(ctx context.Context, req resource.ReadRequest, r
 	if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Metabase addon", addonRes.Error().Error())
 	} else {
-		addon := addonRes.Payload()
-		state.Region = pkg.FromStr(addon.Region)
+		addonPayload := addonRes.Payload()
+		state.Region = pkg.FromStr(addonPayload.Region)
 	}
+
+	state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonId, state.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -126,6 +148,12 @@ func (r *ResourceMetabase) Update(ctx context.Context, req resource.UpdateReques
 		resp.Diagnostics.AddError("failed to update Metabase", addonRes.Error().Error())
 	} else {
 		state.Name = pkg.FromStr(addonRes.Payload().Name)
+	}
+
+	if addonID, err := tmp.RealIDToAddonID(ctx, r.Client(), r.Organization(), state.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to get addon ID", err.Error())
+	} else {
+		resources.SyncTags(ctx, r, resources.AddonTags, addonID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)

--- a/pkg/resources/software/metabase/metabase_test.go
+++ b/pkg/resources/software/metabase/metabase_test.go
@@ -20,11 +20,12 @@ func TestAccMetabase_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-mb")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_metabase.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	metabaseBlock := helper.NewRessource(
 		"clevercloud_metabase",
 		rName,
-		helper.SetKeyValues(map[string]any{"name": rName, "region": "par"}),
+		helper.SetKeyValues(map[string]any{"name": rName, "region": "par", "tags": []string{"foo", "bar"}}),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -37,6 +38,15 @@ func TestAccMetabase_basic(t *testing.T) {
 			ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^metabase_.*`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: rName,

--- a/pkg/resources/software/metabase/schema.go
+++ b/pkg/resources/software/metabase/schema.go
@@ -13,10 +13,12 @@ import (
 )
 
 type Metabase struct {
-	ID     types.String `tfsdk:"id"`
-	Name   types.String `tfsdk:"name"`
-	Region types.String `tfsdk:"region"`
-	Host   types.String `tfsdk:"host"`
+	ID      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Host    types.String `tfsdk:"host"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 }
 
 //go:embed doc.md
@@ -36,6 +38,16 @@ func (r ResourceMetabase) Schema(_ context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "Geographical region where the data will be stored",
 			},
 			"host": schema.StringAttribute{Computed: true, MarkdownDescription: "Metabase host, used to connect to"},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the addon",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the addon: the resource `tags` merged with the provider-level `default_tags`",
+			},
 		},
 	}
 }

--- a/pkg/resources/software/otoroshi/crud.go
+++ b/pkg/resources/software/otoroshi/crud.go
@@ -8,8 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
+
+// ModifyPlan recomputes the effective `tags_all` (provider defaults merged with the
+// resource `tags`) at plan time, so a provider-level default_tags change propagates to
+// existing resources.
+func (r *ResourceOtoroshi) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || r.Provider == nil {
+		return
+	}
+
+	plan := helper.PlanFrom[Otoroshi](ctx, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.TagsAll = pkg.ComputeTagsAll(ctx, r.DefaultTags(), plan.Tags, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
 
 func (r *ResourceOtoroshi) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	state := helper.PlanFrom[Otoroshi](ctx, req.Plan, &resp.Diagnostics)
@@ -75,6 +93,8 @@ func (r *ResourceOtoroshi) Create(ctx context.Context, req resource.CreateReques
 		state.URL = pkg.FromStr(otoroshi.AccessURL)
 	}
 
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.ID, state.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -96,10 +116,12 @@ func (r *ResourceOtoroshi) Read(ctx context.Context, req resource.ReadRequest, r
 	} else if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Otoroshi", addonRes.Error().Error())
 	} else {
-		addon := addonRes.Payload()
-		state.Name = pkg.FromStr(addon.Name)
-		state.Region = pkg.FromStr(addon.Region)
-		state.CreationDate = pkg.FromI(addon.CreationDate)
+		addonPayload := addonRes.Payload()
+		state.Name = pkg.FromStr(addonPayload.Name)
+		state.Region = pkg.FromStr(addonPayload.Region)
+		state.CreationDate = pkg.FromI(addonPayload.CreationDate)
+
+		state.Tags, state.TagsAll = resources.ReadTags(ctx, r, resources.AddonTags, addonPayload.ID, state.Tags, &resp.Diagnostics)
 	}
 
 	otoroshiRes := tmp.GetOtoroshi(ctx, r.Client(), state.ID.ValueString())
@@ -144,6 +166,8 @@ func (r *ResourceOtoroshi) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	resources.SyncTags(ctx, r, resources.AddonTags, addonRes.Payload().ID, plan.Tags, &state.Tags, &state.TagsAll, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/software/otoroshi/otoroshi_test.go
+++ b/pkg/resources/software/otoroshi/otoroshi_test.go
@@ -20,13 +20,15 @@ func TestAccOtoroshi_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test-otoroshi")
 	rNameEdited := rName + "-edit"
 	fullName := fmt.Sprintf("clevercloud_otoroshi.%s", rName)
-	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).
+		SetKeyValues(map[string]any{"default_tags": []string{"managed"}})
 	otoroshiBlock := helper.NewRessource(
 		"clevercloud_otoroshi",
 		rName,
 		helper.SetKeyValues(map[string]any{
 			"name":   rName,
 			"region": "par",
+			"tags":   []string{"foo", "bar"},
 		}))
 
 	resource.Test(t, resource.TestCase{
@@ -45,6 +47,15 @@ func TestAccOtoroshi_basic(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("initial_admin_login"), knownvalue.StringExact("cc-account-admin")),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("initial_admin_password"), knownvalue.StringRegexp(regexp.MustCompile(`^[a-zA-Z0-9]+$`))),
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("url"), knownvalue.StringRegexp(regexp.MustCompile(`^https://.*-ui-otoroshi\.services\.clever-cloud\.com$`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+				})),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("tags_all"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.StringExact("bar"),
+					knownvalue.StringExact("foo"),
+					knownvalue.StringExact("managed"),
+				})),
 			},
 		}, {
 			ResourceName: "otoroshi_" + rName,

--- a/pkg/resources/software/otoroshi/schema.go
+++ b/pkg/resources/software/otoroshi/schema.go
@@ -16,8 +16,10 @@ import (
 type Otoroshi struct {
 	ID types.String `tfsdk:"id"`
 
-	Name   types.String `tfsdk:"name"`
-	Region types.String `tfsdk:"region"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Tags    types.Set    `tfsdk:"tags"`
+	TagsAll types.Set    `tfsdk:"tags_all"`
 
 	CreationDate types.Int64  `tfsdk:"creation_date"`
 	Version      types.String `tfsdk:"version"`
@@ -52,6 +54,16 @@ func (r ResourceOtoroshi) Schema(_ context.Context, req resource.SchemaRequest, 
 			"version": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Otoroshi version to deploy",
+			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Tags of the Otoroshi",
+			},
+			"tags_all": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "All tags applied to the Otoroshi: the resource `tags` merged with the provider-level `default_tags`",
 			},
 
 			// provider

--- a/pkg/resources/tags.go
+++ b/pkg/resources/tags.go
@@ -1,0 +1,108 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/miton18/helper/set"
+	"go.clever-cloud.com/terraform-provider/pkg"
+	"go.clever-cloud.com/terraform-provider/pkg/provider"
+	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+	"go.clever-cloud.dev/client"
+)
+
+// TagsEndpoint describes where a resource kind's tags live on the API.
+type TagsEndpoint struct {
+	Kind   string // used in error messages and logs
+	Get    func(ctx context.Context, cc *client.Client, organisation string, id string) client.Response[[]string]
+	Add    func(ctx context.Context, cc *client.Client, organisation string, id string, tag string) client.Response[any]
+	Delete func(ctx context.Context, cc *client.Client, organisation string, id string, tag string) client.Response[any]
+}
+
+var AddonTags = TagsEndpoint{"addon", tmp.GetAddonTags, tmp.AddAddonTag, tmp.DeleteAddonTag}
+var ApplicationTags = TagsEndpoint{"application", tmp.GetAppTags, tmp.AddAppTag, tmp.DeleteAppTag}
+
+// SyncTags reconciles the tags set on a resource with the effective set (provider
+// default_tags merged with the resource-level tagsSet): it removes tags that are no
+// longer wanted and adds the missing ones. It is order-insensitive and idempotent.
+//
+// It writes the resource-level tags to stateTarget and the effective merged set to
+// tagsAllTarget, so provider tags never leak into the resource's own `tags` attribute
+// (which would cause a perpetual diff) while `tags_all` reflects reality.
+//
+// For AddonTags, id MUST be the addon ID (addon_xxx), not the realId (e.g. cellar_xxx,
+// postgresql_xxx) — the tags endpoint does not accept the realId. Use
+// tmp.RealIDToAddonID to convert when only the realId is at hand.
+func SyncTags(
+	ctx context.Context,
+	prov provider.Provider,
+	ep TagsEndpoint,
+	id string,
+	tagsSet types.Set,
+	stateTarget *types.Set,
+	tagsAllTarget *types.Set,
+	diags *diag.Diagnostics,
+) {
+	resourceTags := pkg.SetToStringSlice(ctx, tagsSet, diags)
+	if diags.HasError() {
+		return
+	}
+	wanted := pkg.MergeTags(prov.DefaultTags(), resourceTags)
+
+	tagsRes := ep.Get(ctx, prov.Client(), prov.Organization(), id)
+	if tagsRes.HasError() {
+		diags.AddError("failed to get "+ep.Kind+" tags", tagsRes.Error().Error())
+		return
+	}
+
+	current := set.New((*tagsRes.Payload())...)
+	wantedSet := set.New(wanted...)
+
+	toRemove := current.Difference(wantedSet).Slice()
+	toAdd := wantedSet.Difference(current).Slice()
+	tflog.Debug(ctx, "syncing "+ep.Kind+" tags", map[string]any{ep.Kind: id, "add": toAdd, "remove": toRemove})
+
+	for _, tag := range toRemove {
+		if res := ep.Delete(ctx, prov.Client(), prov.Organization(), id, tag); res.HasError() && !res.IsNotFoundError() {
+			diags.AddError("failed to remove "+ep.Kind+" tag", res.Error().Error())
+			return
+		}
+		tflog.Info(ctx, "removed "+ep.Kind+" tag", map[string]any{ep.Kind: id, "tag": tag})
+	}
+	for _, tag := range toAdd {
+		if res := ep.Add(ctx, prov.Client(), prov.Organization(), id, tag); res.HasError() {
+			diags.AddError("failed to add "+ep.Kind+" tag", res.Error().Error())
+			return
+		}
+		tflog.Info(ctx, "added "+ep.Kind+" tag", map[string]any{ep.Kind: id, "tag": tag})
+	}
+
+	*stateTarget = tagsSet
+	*tagsAllTarget = pkg.FromSetString(wanted, diags)
+}
+
+// ReadTags fetches the tags currently set on a resource and returns both the
+// resource-level tags (the API tags minus the provider default_tags) and the effective
+// merged set (`tags_all`, all API tags). It preserves a null state when the user never
+// declared tags and there are no resource-level tags on the API, to avoid a spurious
+// diff on the Optional attribute.
+//
+// For AddonTags, id MUST be the addon ID (addon_xxx), not the realId.
+func ReadTags(
+	ctx context.Context,
+	prov provider.Provider,
+	ep TagsEndpoint,
+	id string,
+	stateTags types.Set,
+	diags *diag.Diagnostics,
+) (tags types.Set, tagsAll types.Set) {
+	tagsRes := ep.Get(ctx, prov.Client(), prov.Organization(), id)
+	if tagsRes.HasError() {
+		diags.AddError("failed to get "+ep.Kind+" tags", tagsRes.Error().Error())
+		return stateTags, basetypes.NewSetUnknown(types.StringType)
+	}
+	return pkg.SplitTags(*tagsRes.Payload(), prov.DefaultTags(), stateTags, diags)
+}

--- a/pkg/strings.go
+++ b/pkg/strings.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -106,6 +107,63 @@ func SetBoolIf(target *types.Bool, s *string, expected string) {
 	if s != nil && *s == expected {
 		*target = types.BoolValue(true)
 	}
+}
+
+// MergeTags returns the sorted union of the provider-level default tags and the
+// resource-level tags — the effective set applied to a taggable resource.
+func MergeTags(defaultTags, resourceTags []string) []string {
+	set := map[string]bool{}
+	for _, tag := range defaultTags {
+		set[tag] = true
+	}
+	for _, tag := range resourceTags {
+		set[tag] = true
+	}
+
+	out := make([]string, 0, len(set))
+	for tag := range set {
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ComputeTagsAll computes the effective tag set (provider defaultTags merged with the
+// resource-level tags) as a types.Set. It is meant to be called from a resource's ModifyPlan
+// to populate the computed `tags_all` attribute — recomputing it at plan time is what makes a
+// provider-level default_tags change propagate to existing resources.
+//
+// If the resource tags are unknown, the result is unknown too.
+func ComputeTagsAll(ctx context.Context, defaultTags []string, resourceTags types.Set, diags *diag.Diagnostics) types.Set {
+	if resourceTags.IsUnknown() {
+		return basetypes.NewSetUnknown(types.StringType)
+	}
+	return FromSetString(MergeTags(defaultTags, SetToStringSlice(ctx, resourceTags, diags)), diags)
+}
+
+// SplitTags separates the full tag set returned by the API into the resource-level `tags`
+// (API tags minus the provider default_tags) and the effective `tags_all` (all API tags).
+//
+// It preserves a null `tags` when the user never declared any (stateTags is null) and there
+// are no resource-level tags on the API, to avoid a spurious diff on the Optional attribute.
+func SplitTags(apiTags, defaultTags []string, stateTags types.Set, diags *diag.Diagnostics) (tags, tagsAll types.Set) {
+	defaults := map[string]bool{}
+	for _, tag := range defaultTags {
+		defaults[tag] = true
+	}
+
+	resourceTags := []string{}
+	for _, tag := range apiTags {
+		if !defaults[tag] {
+			resourceTags = append(resourceTags, tag)
+		}
+	}
+
+	tagsAll = FromSetString(apiTags, diags)
+	if stateTags.IsNull() && len(resourceTags) == 0 {
+		return stateTags, tagsAll
+	}
+	return FromSetString(resourceTags, diags), tagsAll
 }
 
 // FromSetSplit splits *string by separator and returns types.Set.

--- a/pkg/tests/tests.go
+++ b/pkg/tests/tests.go
@@ -9,8 +9,13 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/provider/impl"
 )
 
+// ProtoV6Provider builds a fresh provider instance per factory call so parallel tests
+// don't share mutable provider configuration (e.g. default_tags). Baking a single
+// impl.New("test")() instance here would let one test's provider config leak into another.
 var ProtoV6Provider = map[string]func() (tfprotov6.ProviderServer, error){
-	"clevercloud": providerserver.NewProtocol6WithError(impl.New("test")()),
+	"clevercloud": func() (tfprotov6.ProviderServer, error) {
+		return providerserver.NewProtocol6WithError(impl.New("test")())()
+	},
 }
 
 var ORGANISATION = os.Getenv("ORGANISATION")

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"net/url"
 	"strings"
 	"time"
 
@@ -455,6 +456,30 @@ func GetAddonEnv(ctx context.Context, cc *client.Client, organisation string, ad
 func UpdateAddon(ctx context.Context, cc *client.Client, organisation string, addon string, env map[string]string) client.Response[AddonResponse] {
 	path := fmt.Sprintf("/v2/organisations/%s/addons/%s", organisation, addon)
 	return client.Put[AddonResponse](ctx, cc, path, env)
+}
+
+// GetAddonTags returns the tags currently set on an addon.
+func GetAddonTags(ctx context.Context, cc *client.Client, organisation string, addon string) client.Response[[]string] {
+	path := fmt.Sprintf("/v2/organisations/%s/addons/%s/tags", organisation, addon)
+	return client.Get[[]string](ctx, cc, path)
+}
+
+// AddAddonTag adds a single tag to an addon.
+func AddAddonTag(ctx context.Context, cc *client.Client, organisation string, addon string, tag string) client.Response[any] {
+	path := fmt.Sprintf("/v2/organisations/%s/addons/%s/tags/%s", organisation, addon, url.PathEscape(tag))
+
+	return retry.WithRetry(ctx, func() client.Response[any] {
+		return client.Put[any](ctx, cc, path, nil)
+	}, fmt.Sprintf("AddAddonTag(%s, %s)", addon, tag))
+}
+
+// DeleteAddonTag removes a single tag from an addon.
+func DeleteAddonTag(ctx context.Context, cc *client.Client, organisation string, addon string, tag string) client.Response[any] {
+	path := fmt.Sprintf("/v2/organisations/%s/addons/%s/tags/%s", organisation, addon, url.PathEscape(tag))
+
+	return retry.WithRetry(ctx, func() client.Response[any] {
+		return client.Delete[any](ctx, cc, path)
+	}, fmt.Sprintf("DeleteAddonTag(%s, %s)", addon, tag))
 }
 
 func UpdateConfigProviderEnv(ctx context.Context, cc *client.Client, organisation string, addon string, envVars EnvVars) client.Response[EnvVars] {

--- a/pkg/tmp/app.go
+++ b/pkg/tmp/app.go
@@ -218,6 +218,30 @@ func DeleteApp(ctx context.Context, cc *client.Client, organisationID, applicati
 	return client.Delete[any](ctx, cc, path)
 }
 
+// GetAppTags returns the tags currently set on an application.
+func GetAppTags(ctx context.Context, cc *client.Client, organisationID, applicationID string) client.Response[[]string] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tags", organisationID, applicationID)
+	return client.Get[[]string](ctx, cc, path)
+}
+
+// AddAppTag adds a single tag to an application.
+func AddAppTag(ctx context.Context, cc *client.Client, organisationID, applicationID, tag string) client.Response[any] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tags/%s", organisationID, applicationID, url.PathEscape(tag))
+
+	return retry.WithRetry(ctx, func() client.Response[any] {
+		return client.Put[any](ctx, cc, path, nil)
+	}, fmt.Sprintf("AddAppTag(%s, %s)", applicationID, tag))
+}
+
+// DeleteAppTag removes a single tag from an application.
+func DeleteAppTag(ctx context.Context, cc *client.Client, organisationID, applicationID, tag string) client.Response[any] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tags/%s", organisationID, applicationID, url.PathEscape(tag))
+
+	return retry.WithRetry(ctx, func() client.Response[any] {
+		return client.Delete[any](ctx, cc, path)
+	}, fmt.Sprintf("DeleteAppTag(%s, %s)", applicationID, tag))
+}
+
 func GetAppEnv(ctx context.Context, cc *client.Client, organisationID string, applicationID string) client.Response[[]Env] {
 	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/env", organisationID, applicationID)
 	return client.Get[[]Env](ctx, cc, path)


### PR DESCRIPTION
## Overview

Adds a two-level tagging system across the provider:

- **`default_tags`** (provider attribute) — tags applied to every taggable resource.
- **`tags`** (per resource, Optional) — the resource's own tags.
- **`tags_all`** (per resource, Computed) — the effective set: `tags` merged with `default_tags`.

Covered resources: all application runtimes, the generic addon, the databases (cellar, elasticsearch, fsbucket, materia_kv, mongodb, mysql, postgresql, pulsar, redis), the software resources (keycloak, matomo, metabase, otoroshi), the config provider and network groups.

Apologies for the size of this PR — tags had to reach every resource, and every resource brought a schema, a CRUD, a test and a doc along. It's less scary than the file count suggests: most of it is the same small wiring repeated.

## Semantics

- `tags_all` is recomputed in each resource's `ModifyPlan`, so changing the provider-level `default_tags` produces a diff on existing resources and propagates on the next apply.
- Provider defaults are subtracted from `tags` on read: provider tags never leak into the resource attribute, so there is no perpetual diff. A null `tags` stays null.
- Network groups cannot be updated in place: any change to the effective tag set **replaces the network group**. A per-resource `ignore_default_tags` opts out of provider defaults. This is called out in the provider and resource docs.

## Implementation

- `pkg/strings.go` — `MergeTags` (sorted union), `ComputeTagsAll` (plan-time `tags_all`), `SplitTags` (read-time split, preserves null).
- `pkg/resources/tags.go` — single `SyncTags` / `ReadTags` implementation parameterized by a `TagsEndpoint` descriptor (`AddonTags`, `ApplicationTags`); set-difference reconciliation and `tflog` output modeled on `SyncNetworkGroups`; deletes tolerate not-found.
- `pkg/tmp` — `Get/Add/DeleteAddonTag` and `Get/Add/DeleteAppTag` against `/v2/organisations/{org}/{addons|applications}/{id}/tags`; tag path segments URL-escaped; retry on mutations.
- Addon tag endpoints require the addon ID (`addon_xxx`), never the realId; Update paths convert via `RealIDToAddonID` where needed.

## Verification

Acceptance tests updated across all resources with `tags` / `tags_all` state checks, plus a dedicated propagation test, all run against the live API:

- `TestAccMateriaKV_tagsPropagation` — create with defaults; change **only** `default_tags` and assert it propagates to `tags_all` on the existing resource without touching `tags`; drop a resource tag and assert it is removed from the API set.
- `TestAccOtoroshi_basic` — tags on an operator-backed resource.

Docs regenerated (`make docs`, validate passing) and examples updated (`examples/main.tf` + per-resource examples) to demonstrate `default_tags`, `tags` and the `tags_all` output.