### PR TITLE
chore(deps): bump go.clever-cloud.dev/sdk to v0.2.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/miton18/helper v0.0.4
 	go.clever-cloud.dev/client v0.1.7
-	go.clever-cloud.dev/sdk v0.2.7
+	go.clever-cloud.dev/sdk v0.2.10
 	golang.org/x/exp v0.0.0-20251017212417-90e834f514db
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1174,8 +1174,8 @@ go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ
 go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
 go.clever-cloud.dev/client v0.1.7 h1:UTOzYOlxRI+tjSx0ykZONJfrcYu4QZzL7iDOM9Z4dho=
 go.clever-cloud.dev/client v0.1.7/go.mod h1:FbR9HINkEq3ilZoKOTWOLgtv5JdNZEggW8cGuRjtODc=
-go.clever-cloud.dev/sdk v0.2.7 h1:AIUkpxxxpx60qQkoAZYe2hJm1pxL/vjqoAuNjJHdFkw=
-go.clever-cloud.dev/sdk v0.2.7/go.mod h1:wTbSUEQLKgbBohz9OMya7bcjBrdoutdaC5JQM7LrXPE=
+go.clever-cloud.dev/sdk v0.2.10 h1:z3YKIf+ZEji9Gl/LrDR8HDTnNjC2XHIRzGo7S4BFWaI=
+go.clever-cloud.dev/sdk v0.2.10/go.mod h1:wTbSUEQLKgbBohz9OMya7bcjBrdoutdaC5JQM7LrXPE=
 go.einride.tech/aip v0.67.1/go.mod h1:ZGX4/zKw8dcgzdLsrvpOOGxfxI2QSk12SlP7d6c0/XI=
 go.einride.tech/aip v0.68.0/go.mod h1:7y9FF8VtPWqpxuAxl0KQWqaULxW4zFIesD6zF5RIHHg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
## Summary
- Bumps `go.clever-cloud.dev/sdk` from v0.2.7 to v0.2.10.
- Only `go.mod` / `go.sum` change; no code changes required.

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` → 114 passed, 99 skipped. The 2 failures are pre-existing environmental issues, unrelated to this bump:
  - `TestPgSqlRowsToJson` requires a running Docker daemon.
  - `TestProvider_ConfigureEmptyOrganisation` expects no org in the environment (fails locally because `CC_ORGANISATION` is set).