### PR TITLE
fix(drain): decode percent-encoded Datadog URL segments on read

### DIFF
--- a/pkg/resources/drain/schema.go
+++ b/pkg/resources/drain/schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -126,23 +127,23 @@ func (r *DatadogDrain) FromAPI(drain tmp.Drain) error {
 
 	// Parse the URL to extract endpoint and API key
 	// URL format: https://http-intake.logs.datadoghq.com/v1/input/<API_KEY>
-	url := recipient.URL
-	lastSlash := strings.LastIndex(url, "/")
+	rawURL := recipient.URL
+	lastSlash := strings.LastIndex(rawURL, "/")
 
 	if lastSlash > 0 {
 		// Preserve endpoint from state if already set, otherwise use API value
 		if r.Endpoint.IsNull() || r.Endpoint.IsUnknown() {
-			r.Endpoint = types.StringValue(url[:lastSlash])
+			r.Endpoint = types.StringValue(unescapeOrRaw(rawURL[:lastSlash]))
 		}
 		// For sensitive attributes, preserve current state value since API doesn't return it
 		if r.APIKey.IsNull() || r.APIKey.IsUnknown() {
-			r.APIKey = types.StringValue(url[lastSlash+1:])
+			r.APIKey = types.StringValue(unescapeOrRaw(rawURL[lastSlash+1:]))
 		}
 		// else: keep existing value from state
 	} else {
 		// Fallback if URL doesn't contain a slash (shouldn't happen)
 		if r.Endpoint.IsNull() || r.Endpoint.IsUnknown() {
-			r.Endpoint = types.StringValue(url)
+			r.Endpoint = types.StringValue(unescapeOrRaw(rawURL))
 		}
 		if r.APIKey.IsNull() || r.APIKey.IsUnknown() {
 			r.APIKey = types.StringNull()
@@ -153,6 +154,16 @@ func (r *DatadogDrain) FromAPI(drain tmp.Drain) error {
 	r.ResourceID = types.StringValue(drain.ApplicationID)
 	r.Kind = types.StringValue(string(drain.Kind))
 	return nil
+}
+
+// unescapeOrRaw decodes percent-encoding, falling back to the raw input on
+// invalid escapes so a malformed segment never breaks a Read/plan.
+func unescapeOrRaw(s string) string {
+	decoded, err := url.PathUnescape(s)
+	if err != nil {
+		return s
+	}
+	return decoded
 }
 
 func (r DatadogDrain) GetDrain() Drain { return r.Drain }

--- a/pkg/resources/drain/schema_test.go
+++ b/pkg/resources/drain/schema_test.go
@@ -1,0 +1,97 @@
+package drain_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg/resources/drain"
+	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+)
+
+func datadogAPIDrain(t *testing.T, url string) tmp.Drain {
+	t.Helper()
+	recipient, err := json.Marshal(map[string]string{
+		"type": "DatadogRecipient",
+		"url":  url,
+	})
+	if err != nil {
+		t.Fatalf("marshal recipient: %v", err)
+	}
+	return tmp.Drain{
+		ID:            "drain_id",
+		ApplicationID: "app_id",
+		Kind:          tmp.DRAIN_KIND_LOG,
+		Recipient:     json.RawMessage(recipient),
+	}
+}
+
+func TestDatadogDrainFromAPI_DecodesPercentEncodedSegments(t *testing.T) {
+	// %2D -> '-', %2F -> '/', %3D -> '=': encoded inside the key segment,
+	// so the literal "/" split still lands on the endpoint/key boundary.
+	apiDrain := datadogAPIDrain(t, "https://http-intake.logs.datadoghq.eu/v1/input/fake%2Dapi%2Dkey%2F123%3D%3D")
+
+	d := &drain.DatadogDrain{}
+	if err := d.FromAPI(apiDrain); err != nil {
+		t.Fatalf("FromAPI returned error: %v", err)
+	}
+
+	if got := d.Endpoint.ValueString(); got != "https://http-intake.logs.datadoghq.eu/v1/input" {
+		t.Errorf("Endpoint = %q, want %q", got, "https://http-intake.logs.datadoghq.eu/v1/input")
+	}
+	if got := d.APIKey.ValueString(); got != "fake-api-key/123==" {
+		t.Errorf("APIKey = %q, want %q", got, "fake-api-key/123==")
+	}
+}
+
+func TestDatadogDrainFromAPI_UnencodedURLUnchanged(t *testing.T) {
+	apiDrain := datadogAPIDrain(t, "https://http-intake.logs.datadoghq.com/v1/input/fake-api-key-plain-123")
+
+	d := &drain.DatadogDrain{}
+	if err := d.FromAPI(apiDrain); err != nil {
+		t.Fatalf("FromAPI returned error: %v", err)
+	}
+
+	if got := d.Endpoint.ValueString(); got != "https://http-intake.logs.datadoghq.com/v1/input" {
+		t.Errorf("Endpoint = %q, want %q", got, "https://http-intake.logs.datadoghq.com/v1/input")
+	}
+	if got := d.APIKey.ValueString(); got != "fake-api-key-plain-123" {
+		t.Errorf("APIKey = %q, want %q", got, "fake-api-key-plain-123")
+	}
+}
+
+func TestDatadogDrainFromAPI_PreservesExistingState(t *testing.T) {
+	// API returns a different (and differently-encoded) URL, but since the
+	// state already has known values, FromAPI must not overwrite them.
+	apiDrain := datadogAPIDrain(t, "https://http-intake.logs.datadoghq.eu/v1/input/other%2Dkey")
+
+	d := &drain.DatadogDrain{
+		Endpoint: types.StringValue("https://http-intake.logs.datadoghq.com/v1/input"),
+		APIKey:   types.StringValue("state-api-key-123"),
+	}
+	if err := d.FromAPI(apiDrain); err != nil {
+		t.Fatalf("FromAPI returned error: %v", err)
+	}
+
+	if got := d.Endpoint.ValueString(); got != "https://http-intake.logs.datadoghq.com/v1/input" {
+		t.Errorf("Endpoint = %q, want state value preserved, got %q", got, "https://http-intake.logs.datadoghq.com/v1/input")
+	}
+	if got := d.APIKey.ValueString(); got != "state-api-key-123" {
+		t.Errorf("APIKey = %q, want state value preserved, got %q", got, "state-api-key-123")
+	}
+}
+
+func TestDatadogDrainFromAPI_InvalidEscapeKeepsRawValue(t *testing.T) {
+	// "%zz" is not a valid percent-escape; PathUnescape errors and the raw
+	// segment must be kept rather than failing the Read.
+	apiDrain := datadogAPIDrain(t, "https://http-intake.logs.datadoghq.eu/v1/input/fake%zzkey")
+
+	d := &drain.DatadogDrain{}
+	if err := d.FromAPI(apiDrain); err != nil {
+		t.Fatalf("FromAPI returned error: %v", err)
+	}
+
+	if got := d.APIKey.ValueString(); got != "fake%zzkey" {
+		t.Errorf("APIKey = %q, want raw value %q preserved on invalid escape", got, "fake%zzkey")
+	}
+}


### PR DESCRIPTION
Closes #372

The Datadog drain resource was redesigned since this issue was filed: it now exposes separate `endpoint` and `api_key` attributes instead of a single concatenated URL (`pkg/resources/drain/schema.go`). Terraform no longer diffs a full encoded-vs-unencoded URL string, so the original root cause described in #372 is gone.

One vestige remained: `DatadogDrain.FromAPI` split the API-returned URL into `endpoint`/`api_key` but never decoded percent-encoding. If the API returns the URL percent-encoded and the state is empty/unknown for these fields, the encoded form landed in state, causing a diff (and `RequiresReplace`) on the next plan — the same symptom as #372, just relocated.

This PR decodes both segments with `url.PathUnescape`, falling back to the raw value if the escape is invalid so a malformed segment never breaks `terraform plan`.