### PR TITLE
feat(application): support TCP redirections

### DIFF
--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -71,6 +71,7 @@ environment = { for k, v in {
 - `ipv6_cidr` (String) Activate the support of IPv6 with an IPv6 subnet int the docker daemon
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `registry_password` (String, Sensitive) The password of your username
 - `registry_url` (String) The server of your private registry (optional).	Docker’s public registry
@@ -187,6 +188,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -111,6 +111,7 @@ environment = { for k, v in {
 - `profile` (String) Override the build configuration settings in your project. Default: Release
 - `proj` (String) The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension.
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `tfm` (String) Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0
@@ -226,6 +227,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -58,6 +58,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -171,6 +172,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -113,6 +113,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -226,6 +227,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -114,6 +114,7 @@ environment = { for k, v in {
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -227,6 +228,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -114,6 +114,7 @@ environment = { for k, v in {
 - `java_version` (String) Choose the JVM version between 7 to 24 for OpenJDK or graalvm-ce for GraalVM 21.0.0.2 (based on OpenJDK 11.0).
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -227,6 +228,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -125,6 +125,7 @@ environment = { for k, v in {
 - `mise_file_path` (String) Custom path for the mise.toml configuration file (relative path).
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `run_command` (String) The command to start your application.
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
@@ -239,6 +240,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -115,6 +115,7 @@ environment = { for k, v in {
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `package_manager` (String) Either npm, npm-ci, bun, pnpm, yarn-berry or custom
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `registry` (String) The host of your private repository, available values: github or the registry host
 - `registry_token` (String, Sensitive) Private repository token
@@ -231,6 +232,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -52,6 +52,7 @@ environment = { for k, v in {
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `php_version` (String) PHP version (Default: 8)
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `redis_sessions` (Boolean) Use a linked Redis instance to store sessions (Default: false)
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
@@ -167,6 +168,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -113,6 +113,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -226,6 +227,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -115,6 +115,7 @@ environment = { for k, v in {
 - `pip_requirements` (String) Define a custom requirements.txt file (default: requirements.txt)
 - `python_version` (String) Python version >= 2.7
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -228,6 +229,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -195,6 +195,7 @@ environment = { for k, v in {
 - `rails_env` (String) Rails environment variable
 - `rake_goals` (String) Comma-separated list of rake goals to execute (e.g., 'db:migrate,assets:precompile')
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `ruby_version` (String) Ruby version to use (e.g., '3.3', '3.3.1')
 - `sidekiq_files` (String) Specify a list of Sidekiq configuration files (e.g., './config/sidekiq_1.yml,./config/sidekiq_2.yml')
@@ -313,6 +314,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -114,6 +114,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -227,6 +228,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -113,6 +113,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -226,6 +227,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -116,6 +116,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -229,6 +230,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -149,6 +149,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -262,6 +263,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -111,6 +111,7 @@ environment = { for k, v in {
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))
 - `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `redirect_https` (Boolean) Redirect client from plain to TLS port
+- `redirection` (Attributes) Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)) (see [below for nested schema](#nestedatt--redirection))
 - `region` (String) Geographical region where the database will be deployed
 - `sticky_sessions` (Boolean) Enable sticky sessions, use it when your client sessions are instances scoped
 - `vhosts` (Attributes Set) List of virtual hosts (see [below for nested schema](#nestedatt--vhosts))
@@ -224,6 +225,18 @@ Required:
 
 - `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
 - `networkgroup_id` (String) ID of the networkgroup
+
+
+<a id="nestedatt--redirection"></a>
+### Nested Schema for `redirection`
+
+Required:
+
+- `namespace` (String) Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)
+
+Read-Only:
+
+- `port` (Number) External port allocated by Clever Cloud for this redirection
 
 
 <a id="nestedatt--vhosts"></a>

--- a/pkg/resources/application/create.go
+++ b/pkg/resources/application/create.go
@@ -163,6 +163,9 @@ func Create[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan T
 	if createRes != nil {
 		runtime.ID = pkg.FromStr(createRes.Application.ID)
 		runtime.SetFromResponse(createRes, ctx, &diags)
+
+		// TCP redirection
+		runtime.Redirection = SyncTCPRedirection(ctx, resource.Client(), resource.Organization(), createRes.Application.ID, runtime.Redirection, nil, &diags)
 	}
 
 	return diags

--- a/pkg/resources/application/nodejs/nodejs_test.go
+++ b/pkg/resources/application/nodejs/nodejs_test.go
@@ -188,3 +188,48 @@ func TestAccNodejs_basic(t *testing.T) {
 		}},
 	})
 }
+
+func TestAccNodejs_tcpRedirection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-node")
+	fullName := fmt.Sprintf("clevercloud_nodejs.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	nodejsBlock := helper.NewRessource(
+		"clevercloud_nodejs",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":               rName,
+			"region":             "par",
+			"min_instance_count": 1,
+			"max_instance_count": 1,
+			"smallest_flavor":    "XS",
+			"biggest_flavor":     "XS",
+			"redirection": map[string]any{
+				"namespace": "default",
+			},
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			Destroy:      false,
+			ResourceName: rName,
+			Config:       providerBlock.Append(nodejsBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("redirection").AtMapKey("namespace"), knownvalue.StringExact("default")),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("redirection").AtMapKey("port"), knownvalue.NotNull()),
+			},
+		}, {
+			ResourceName: rName,
+			Config: providerBlock.Append(
+				nodejsBlock.UnsetOneValue("redirection"),
+			).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("redirection"), knownvalue.Null()),
+			},
+		}},
+	})
+}

--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -130,6 +130,9 @@ func Read[T RuntimePlan](ctx context.Context, resource RuntimeResource, state T)
 	// Read linked dependencies (addons)
 	runtime.Dependencies = ReadDependencies(ctx, resource.Client(), resource.Organization(), runtime.ID.ValueString(), runtime.Dependencies, &diags)
 
+	// Read TCP redirection
+	runtime.Redirection = ReadTCPRedirection(ctx, resource.Client(), resource.Organization(), runtime.ID.ValueString(), runtime.Redirection, &diags)
+
 	// Map environment variables to runtime-specific fields
 	state.FromEnv(ctx, env, &diags)
 

--- a/pkg/resources/application/runtime.go
+++ b/pkg/resources/application/runtime.go
@@ -30,6 +30,13 @@ func (vh VHost) String() *string {
 	return &vhost
 }
 
+// TCPRedirection represents a TCP redirection exposing the application
+// local port 4040 on an external port
+type TCPRedirection struct {
+	Namespace types.String `tfsdk:"namespace"`
+	Port      types.Int64  `tfsdk:"port"`
+}
+
 // Runtime represents the common fields for all application runtimes
 type Runtime struct {
 	ID               types.String             `tfsdk:"id"`
@@ -50,6 +57,7 @@ type Runtime struct {
 	Deployment       *attributes.Deployment   `tfsdk:"deployment"`
 	Hooks            *attributes.Hooks        `tfsdk:"hooks"`
 	Integrations     *attributes.Integrations `tfsdk:"integrations"`
+	Redirection      *TCPRedirection          `tfsdk:"redirection"`
 
 	// Env
 	AppFolder          types.String `tfsdk:"app_folder"`

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -191,6 +191,21 @@ var runtimeCommon = map[string]schema.Attribute{
 		},
 	},
 	"integrations": attributes.IntegrationsAttribute,
+	"redirection": schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/))",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Namespace in which the TCP redirection is open (usually `default` or `cleverapps`)",
+			},
+			"port": schema.Int64Attribute{
+				Computed:            true,
+				MarkdownDescription: "External port allocated by Clever Cloud for this redirection",
+				PlanModifiers:       []planmodifier.Int64{UseStatePortWhenNamespaceUnchanged()},
+			},
+		},
+	},
 }
 
 // runtimeCommonV0 defines common schema attributes for schema version 0 (for state upgrades)

--- a/pkg/resources/application/tcp_redirections.go
+++ b/pkg/resources/application/tcp_redirections.go
@@ -1,0 +1,119 @@
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg"
+	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+	"go.clever-cloud.dev/client"
+)
+
+// SyncTCPRedirection reconciles the application TCP redirection with the plan.
+// state is the previously managed redirection (nil on Create).
+// It returns the redirection to persist, with its allocated port, or nil when
+// no redirection is planned.
+func SyncTCPRedirection(ctx context.Context, cc *client.Client, organisation, applicationID string, plan, state *TCPRedirection, diags *diag.Diagnostics) *TCPRedirection {
+	// nothing planned and nothing managed: leave remote redirections untouched
+	if plan == nil && state == nil {
+		return nil
+	}
+
+	redirsRes := tmp.GetTCPRedirections(ctx, cc, organisation, applicationID)
+	if redirsRes.HasError() {
+		diags.AddError("failed to get application TCP redirections", redirsRes.Error().Error())
+		return state
+	}
+
+	var result *TCPRedirection
+	for _, redir := range *redirsRes.Payload() {
+		if plan != nil && redir.Namespace == plan.Namespace.ValueString() {
+			// redirection already exists, adopt its allocated port
+			result = &TCPRedirection{Namespace: pkg.FromStr(redir.Namespace), Port: pkg.FromI(redir.Port)}
+			continue
+		}
+
+		// only remove redirections previously managed by this resource
+		if state != nil && redir.Namespace == state.Namespace.ValueString() {
+			deleteRes := tmp.DeleteTCPRedirection(ctx, cc, organisation, applicationID, redir.Port, redir.Namespace)
+			if deleteRes.HasError() {
+				diags.AddError(fmt.Sprintf("failed to delete TCP redirection on namespace %q", redir.Namespace), deleteRes.Error().Error())
+			}
+		}
+	}
+
+	if plan != nil && result == nil {
+		createRes := tmp.CreateTCPRedirection(ctx, cc, organisation, applicationID, tmp.CreateTCPRedirectionRequest{
+			Namespace: plan.Namespace.ValueString(),
+		})
+		if createRes.HasError() {
+			diags.AddError(fmt.Sprintf("failed to create TCP redirection on namespace %q", plan.Namespace.ValueString()), createRes.Error().Error())
+			return nil
+		}
+		result = &TCPRedirection{Namespace: plan.Namespace, Port: pkg.FromI(createRes.Payload().Port)}
+	}
+
+	return result
+}
+
+// ReadTCPRedirection refreshes the managed TCP redirection from the API to
+// detect drift. Redirections created outside Terraform are not adopted.
+func ReadTCPRedirection(ctx context.Context, cc *client.Client, organisation, applicationID string, state *TCPRedirection, diags *diag.Diagnostics) *TCPRedirection {
+	if state == nil {
+		return nil
+	}
+
+	redirsRes := tmp.GetTCPRedirections(ctx, cc, organisation, applicationID)
+	if redirsRes.HasError() {
+		diags.AddError("failed to get application TCP redirections", redirsRes.Error().Error())
+		return state
+	}
+
+	for _, redir := range *redirsRes.Payload() {
+		if redir.Namespace == state.Namespace.ValueString() {
+			return &TCPRedirection{Namespace: pkg.FromStr(redir.Namespace), Port: pkg.FromI(redir.Port)}
+		}
+	}
+
+	// redirection was removed outside Terraform
+	return nil
+}
+
+// UseStatePortWhenNamespaceUnchanged keeps the port value from state as long
+// as the redirection namespace does not change: changing the namespace
+// recreates the redirection, so a new port will be allocated.
+func UseStatePortWhenNamespaceUnchanged() planmodifier.Int64 {
+	return tcpRedirectionPortModifier{}
+}
+
+type tcpRedirectionPortModifier struct{}
+
+func (tcpRedirectionPortModifier) Description(context.Context) string {
+	return "Keep the allocated port from state while the namespace is unchanged"
+}
+
+func (m tcpRedirectionPortModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (tcpRedirectionPortModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, res *planmodifier.Int64Response) {
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	namespacePath := req.Path.ParentPath().AtName("namespace")
+
+	var planNamespace, stateNamespace types.String
+	res.Diagnostics.Append(req.Plan.GetAttribute(ctx, namespacePath, &planNamespace)...)
+	res.Diagnostics.Append(req.State.GetAttribute(ctx, namespacePath, &stateNamespace)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	if planNamespace.Equal(stateNamespace) {
+		res.PlanValue = req.StateValue
+	}
+}

--- a/pkg/resources/application/update.go
+++ b/pkg/resources/application/update.go
@@ -160,5 +160,8 @@ func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, 
 		runtime.SetFromResponse(updatedApp, ctx, &diags)
 	}
 
+	// TCP redirection
+	runtime.Redirection = SyncTCPRedirection(ctx, resource.Client(), resource.Organization(), stateRuntime.ID.ValueString(), runtime.Redirection, stateRuntime.Redirection, &diags)
+
 	return diags
 }

--- a/pkg/tmp/app.go
+++ b/pkg/tmp/app.go
@@ -463,3 +463,30 @@ func RemoveAppDependency(ctx context.Context, cc *client.Client, organisationID,
 	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/dependencies/%s", organisationID, applicationID, dependencyAppID)
 	return client.Delete[client.Nothing](ctx, cc, path)
 }
+
+// TCP redirections expose the application's local port 4040 on an external port
+// See: https://www.clever.cloud/developers/doc/administrate/tcp-redirections/
+
+type TCPRedirection struct {
+	Namespace string `json:"namespace"`
+	Port      int64  `json:"port"`
+}
+
+func GetTCPRedirections(ctx context.Context, cc *client.Client, organisationID, applicationID string) client.Response[[]TCPRedirection] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tcpRedirs", organisationID, applicationID)
+	return client.Get[[]TCPRedirection](ctx, cc, path)
+}
+
+type CreateTCPRedirectionRequest struct {
+	Namespace string `json:"namespace"`
+}
+
+func CreateTCPRedirection(ctx context.Context, cc *client.Client, organisationID, applicationID string, req CreateTCPRedirectionRequest) client.Response[TCPRedirection] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tcpRedirs", organisationID, applicationID)
+	return client.Post[TCPRedirection](ctx, cc, path, req)
+}
+
+func DeleteTCPRedirection(ctx context.Context, cc *client.Client, organisationID, applicationID string, port int64, namespace string) client.Response[client.Nothing] {
+	path := fmt.Sprintf("/v2/organisations/%s/applications/%s/tcpRedirs/%d?namespace=%s", organisationID, applicationID, port, url.QueryEscape(namespace))
+	return client.Delete[client.Nothing](ctx, cc, path)
+}


### PR DESCRIPTION
Closes #402

Adds TCP redirection support to every application runtime, following the schema proposed in the issue:

```hcl
resource "clevercloud_nodejs" "app" {
  name = "my_app"
  # ...
  redirection = {
    namespace = "default" # required
    # port     -> computed, allocated by Clever Cloud
  }
}
```

## Implementation

- **`pkg/tmp/app.go`**: `GetTCPRedirections` / `CreateTCPRedirection` / `DeleteTCPRedirection` on the legacy v2 `tcpRedirs` endpoints (no OpenAPI generation for this API).
- **Common runtime schema**: `redirection` single nested attribute (`namespace` required, `port` computed), available on all 16 application runtimes.
- **Reconciliation** in the shared `Create`/`Update`/`Read` flows (`pkg/resources/application/tcp_redirections.go`):
  - create allocates the redirection and persists the returned port
  - removing the attribute deletes the redirection; changing the namespace recreates it (new port)
  - `Read` detects drift (port change / deletion outside Terraform)
  - redirections created outside Terraform in other namespaces are never touched, and none are adopted when the attribute is unset
- A custom plan modifier keeps the allocated `port` from state while the namespace is unchanged, avoiding a perpetual `(known after apply)` diff.

## Tests

- `TestAccNodejs_tcpRedirection` (create with redirection, then remove it): **passes against the real API** (~13s).
- Unit tests and `go vet` pass; docs regenerated with `tfplugindocs`.