### PR TITLE
feat(otoroshi): support networkgroups

### DIFF
--- a/docs/resources/otoroshi.md
+++ b/docs/resources/otoroshi.md
@@ -33,6 +33,7 @@ Learn more about [Otoroshi with LLM](https://www.clever.cloud/developers/doc/add
 
 ### Optional
 
+- `networkgroups` (Attributes Set) List of networkgroups the application must be part of (see [below for nested schema](#nestedatt--networkgroups))
 - `region` (String) Geographical region where the data will be stored
 - `version` (String) Otoroshi version to deploy
 
@@ -46,3 +47,11 @@ Learn more about [Otoroshi with LLM](https://www.clever.cloud/developers/doc/add
 - `initial_admin_login` (String) Initial admin login
 - `initial_admin_password` (String, Sensitive) Initial admin password
 - `url` (String) URL
+
+<a id="nestedatt--networkgroups"></a>
+### Nested Schema for `networkgroups`
+
+Required:
+
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `networkgroup_id` (String) ID of the networkgroup

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -18,6 +18,7 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/provider"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 )
 
 // runtimeCommon defines common schema attributes for all application runtimes
@@ -173,24 +174,8 @@ var runtimeCommon = map[string]schema.Attribute{
 			}),
 		},
 	},
-	"networkgroups": schema.SetNestedAttribute{
-		Optional:            true,
-		MarkdownDescription: "List of networkgroups the application must be part of",
-		NestedObject: schema.NestedAttributeObject{
-			Attributes: map[string]schema.Attribute{
-				"networkgroup_id": schema.StringAttribute{
-					Required:            true,
-					MarkdownDescription: "ID of the networkgroup",
-				},
-				"fqdn": schema.StringAttribute{
-					Required:            true,
-					MarkdownDescription: "domain name which will resolve to application instances inside the networkgroup",
-					//Default: stringdefault.StaticString(),
-				},
-			},
-		},
-	},
-	"integrations": attributes.IntegrationsAttribute,
+	"networkgroups": resources.NetworkgroupsAttribute,
+	"integrations":  attributes.IntegrationsAttribute,
 	"redirection": schema.SingleNestedAttribute{
 		Optional:            true,
 		MarkdownDescription: "Expose the application local port 4040 on an external TCP port ([TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/))",

--- a/pkg/resources/ng.go
+++ b/pkg/resources/ng.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/miton18/helper/set"
@@ -25,6 +26,26 @@ var networkgroupConfigSchema = map[string]attr.Type{
 	"fqdn":            types.StringType,
 }
 var NullNetworkgroupConfig = types.SetNull(types.ObjectType{AttrTypes: networkgroupConfigSchema})
+
+// NetworkgroupsAttribute is the shared schema for the "networkgroups"
+// attribute, used by application runtimes and by add-ons piloting their
+// underlying application
+var NetworkgroupsAttribute = schema.SetNestedAttribute{
+	Optional:            true,
+	MarkdownDescription: "List of networkgroups the application must be part of",
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"networkgroup_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "ID of the networkgroup",
+			},
+			"fqdn": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "domain name which will resolve to application instances inside the networkgroup",
+			},
+		},
+	},
+}
 
 func SyncNetworkGroups(
 	ctx context.Context,

--- a/pkg/resources/software/otoroshi/crud.go
+++ b/pkg/resources/software/otoroshi/crud.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
+	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
 )
 
@@ -73,6 +75,9 @@ func (r *ResourceOtoroshi) Create(ctx context.Context, req resource.CreateReques
 		state.InitialAdminLogin = pkg.FromStr(otoroshi.Initialredentials.User)
 		state.InitialAdminPassword = pkg.FromStr(otoroshi.Initialredentials.Passsword)
 		state.URL = pkg.FromStr(otoroshi.AccessURL)
+
+		// Networkgroups are piloted on the Java application backing the add-on
+		application.SyncNetworkGroups(ctx, r, otoroshi.Resources.Entrypoint, state.Networkgroups, &resp.Diagnostics)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -115,6 +120,9 @@ func (r *ResourceOtoroshi) Read(ctx context.Context, req resource.ReadRequest, r
 		state.InitialAdminLogin = pkg.FromStr(otoroshi.Initialredentials.User)
 		state.InitialAdminPassword = pkg.FromStr(otoroshi.Initialredentials.Passsword)
 		state.URL = pkg.FromStr(otoroshi.AccessURL)
+
+		// Networkgroups are piloted on the Java application backing the add-on
+		state.Networkgroups = resources.ReadNetworkGroups(ctx, r, otoroshi.Resources.Entrypoint, &resp.Diagnostics)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -144,6 +152,15 @@ func (r *ResourceOtoroshi) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 	state.Name = pkg.FromStr(addonRes.Payload().Name)
+
+	// Networkgroups are piloted on the Java application backing the add-on
+	otoroshiRes := tmp.GetOtoroshi(ctx, r.Client(), plan.ID.ValueString())
+	if otoroshiRes.HasError() {
+		resp.Diagnostics.AddError("failed to get Otoroshi", otoroshiRes.Error().Error())
+	} else {
+		application.SyncNetworkGroups(ctx, r, otoroshiRes.Payload().Resources.Entrypoint, plan.Networkgroups, &resp.Diagnostics)
+		state.Networkgroups = plan.Networkgroups
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/pkg/resources/software/otoroshi/otoroshi_test.go
+++ b/pkg/resources/software/otoroshi/otoroshi_test.go
@@ -5,14 +5,18 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tests"
+	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+	"go.clever-cloud.dev/client"
 )
 
 func TestAccOtoroshi_basic(t *testing.T) {
@@ -62,5 +66,121 @@ func TestAccOtoroshi_basic(t *testing.T) {
 			},
 		}},
 		CheckDestroy: tests.CheckDestroy(ctx),
+	})
+}
+
+func TestAccOtoroshi_networkgroup(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	cc := client.New(client.WithAutoOauthConfig())
+	rName := acctest.RandomWithPrefix("tf-test-otoroshi")
+	ngName := acctest.RandomWithPrefix("tf-test-otoroshi-ng")
+	fullName := fmt.Sprintf("clevercloud_otoroshi.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+
+	ngBlock := helper.NewRessource(
+		"clevercloud_networkgroup",
+		ngName,
+		helper.SetKeyValues(map[string]any{
+			"name":        ngName,
+			"description": "for otoroshi ng tests",
+			"tags":        []string{"otoroshi"},
+		}),
+	)
+
+	otoroshiBlock := helper.NewRessource(
+		"clevercloud_otoroshi",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"networkgroups": []map[string]string{{
+				"networkgroup_id": fmt.Sprintf("${clevercloud_networkgroup.%s.id}", ngName),
+				"fqdn":            "myotoroshi",
+			}}}),
+	)
+
+	otoroshiBlock2 := helper.NewRessource(
+		"clevercloud_otoroshi",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":          rName,
+			"region":        "par",
+			"networkgroups": nil,
+		}),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 tests.ExpectOrganisation(t),
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			ResourceName: "otoroshi_" + rName,
+			Config:       providerBlock.Append(ngBlock, otoroshiBlock).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^otoroshi_.*`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("networkgroups"), knownvalue.SetExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"networkgroup_id": knownvalue.StringRegexp(regexp.MustCompile("^ng_.*$")),
+						"fqdn":            knownvalue.StringExact("myotoroshi"),
+					}),
+				})),
+			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				func(s *terraform.State) error {
+					ngResource := s.RootModule().Resources["clevercloud_networkgroup."+ngName]
+					otoroshiResource := s.RootModule().Resources[fullName]
+					ngID := ngResource.Primary.ID
+
+					otoroshiRes := tmp.GetOtoroshi(ctx, cc, otoroshiResource.Primary.ID)
+					if otoroshiRes.HasError() {
+						return fmt.Errorf("failed to get otoroshi: %w", otoroshiRes.Error())
+					}
+					entrypoint := otoroshiRes.Payload().Resources.Entrypoint
+
+					membersRes := tmp.ListMembers(ctx, cc, tests.ORGANISATION, ngID)
+					if membersRes.HasError() {
+						return fmt.Errorf("failed to list members: %w", membersRes.Error())
+					}
+					members := *membersRes.Payload()
+
+					if len(members) != 1 {
+						return fmt.Errorf("expect 1 member, got: %d", len(members))
+					}
+					member := members[0]
+
+					if member.ID != entrypoint {
+						return fmt.Errorf("expect member to be the underlying app %s, got: %s", entrypoint, member.ID)
+					}
+					return nil
+				},
+			),
+		}, {
+			ResourceName: "otoroshi_" + rName,
+			Config:       providerBlock.Append(ngBlock, otoroshiBlock2).String(),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^otoroshi_.*`))),
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("networkgroups"), knownvalue.Null()),
+			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				func(s *terraform.State) error {
+					time.Sleep(5 * time.Second) // NG API is asynchronous
+					ngResource := s.RootModule().Resources["clevercloud_networkgroup."+ngName]
+					ngID := ngResource.Primary.ID
+
+					membersRes := tmp.ListMembers(ctx, cc, tests.ORGANISATION, ngID)
+					if membersRes.HasError() {
+						return fmt.Errorf("failed to list members: %w", membersRes.Error())
+					}
+					members := *membersRes.Payload()
+
+					if len(members) != 0 {
+						return fmt.Errorf("expect 0 member, got: %+v", members)
+					}
+
+					return nil
+				},
+			),
+		}},
 	})
 }

--- a/pkg/resources/software/otoroshi/schema.go
+++ b/pkg/resources/software/otoroshi/schema.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 )
 
 type Otoroshi struct {
@@ -28,6 +29,8 @@ type Otoroshi struct {
 	InitialAdminLogin    types.String `tfsdk:"initial_admin_login"`
 	InitialAdminPassword types.String `tfsdk:"initial_admin_password"`
 	URL                  types.String `tfsdk:"url"`
+
+	Networkgroups types.Set `tfsdk:"networkgroups"`
 }
 
 //go:embed doc.md
@@ -53,6 +56,7 @@ func (r ResourceOtoroshi) Schema(_ context.Context, req resource.SchemaRequest, 
 				Optional:            true,
 				MarkdownDescription: "Otoroshi version to deploy",
 			},
+			"networkgroups": resources.NetworkgroupsAttribute,
 
 			// provider
 			"id": schema.StringAttribute{

--- a/pkg/tmp/addon.go
+++ b/pkg/tmp/addon.go
@@ -395,7 +395,7 @@ type OtoroshiInfo struct {
 	AccessURL         string            `json:"accessUrl"`
 	API               *OtoroshiAPI      `json:"api"`
 	AvailableVersions []string          `json:"availableVersions"`
-	Resources         map[string]string `json:"resources"`
+	Resources         OtoroshiResources `json:"resources"`
 	Features          map[string]any    `json:"features"`
 	EnvVars           map[string]string `json:"envVars"`
 	Initialredentials struct {
@@ -407,6 +407,16 @@ type OtoroshiAPI struct {
 	URL    string `json:"url"`
 	User   string `json:"user"`
 	Secret string `json:"secret"`
+}
+
+type OtoroshiResources struct {
+	// Entrypoint is the ID of the Java application backing the Otoroshi add-on
+	Entrypoint   string  `json:"entrypoint"`
+	RedisID      string  `json:"redisId"`
+	CellarID     *string `json:"cellarId"`
+	PulsarID     *string `json:"pulsarId"`
+	ElasticID    *string `json:"elasticId"`
+	PostgresqlID *string `json:"postgresqlId"`
 }
 
 // Use real ID


### PR DESCRIPTION
Closes #417

Adds the same `networkgroups` attribute as application runtimes to the `clevercloud_otoroshi` resource:

```hcl
resource "clevercloud_otoroshi" "gateway" {
  name = "my-gateway"
  networkgroups = [{
    networkgroup_id = clevercloud_networkgroup.ng.id
    fqdn            = "myotoroshi"
  }]
}
```

## Implementation

As requested in the issue, membership is piloted on the **Java application backing the add-on** (`resources.entrypoint` in the v4 `addon-otoroshi` payload) — Otoroshi's own networkgroup feature is not used. Verified against the real API that the entrypoint app belongs to the customer organisation, so the existing generic member sync applies as-is with kind `APPLICATION`.

- **`pkg/tmp/addon.go`**: `OtoroshiInfo.Resources` is now a typed `OtoroshiResources` struct (`entrypoint`, `redisId`, optional backing-service IDs) instead of `map[string]string`.
- **`pkg/resources/ng.go`**: the `networkgroups` schema attribute is extracted as `resources.NetworkgroupsAttribute`, shared between application runtimes and otoroshi (no change to the generated runtime schemas).
- **`pkg/resources/software/otoroshi/`**: `networkgroups` in model + schema; Create/Update sync membership of the entrypoint app via the shared `SyncNetworkGroups`, Read refreshes it via `ReadNetworkGroups` for drift detection.

## Tests

- `TestAccOtoroshi_networkgroup`: **passes against the real API** (~22s) — creates a networkgroup + otoroshi, asserts via the members API that the NG member is the underlying entrypoint app, then removes the attribute and asserts the membership is gone.
- Unit tests, `go vet` pass; docs regenerated (only `otoroshi.md` changes).