### PR TITLE
docs(provider): document Cellar as Terraform S3 backend

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,38 @@ description: |-
   
   Where:
   USER is the GitHub username of the person who created the tokenPAT_TOKEN is the Personal Access Token generated in the previous step
+  Store the Terraform state on Cellar
+  A Cellar https://www.clever.cloud/developers/doc/addons/cellar/ bucket can store your Terraform state through the S3 backend https://developer.hashicorp.com/terraform/language/backend/s3. The backend must exist before terraform init, so use a Cellar add-on and a bucket created beforehand (from the Console https://console.clever-cloud.com/ or the CLI):
+  
+  terraform {
+    backend "s3" {
+      bucket = "my-terraform-state-bucket"
+      key    = "my-project.tfstate"
+      region = "us-east-1"
+      endpoints = {
+        s3 = "https://cellar-c2.services.clever-cloud.com"
+      }
+  
+      use_path_style              = true
+      skip_region_validation      = true
+      skip_credentials_validation = true
+      skip_metadata_api_check     = true
+      skip_requesting_account_id  = true
+    }
+  }
+  
+  Credentials are read from the standard AWS environment variables, filled with the Cellar add-on ones:
+  
+  export AWS_ACCESS_KEY_ID="$CELLAR_ADDON_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$CELLAR_ADDON_KEY_SECRET"
+  
+  ~> Recent Terraform versions upload the state with a trailing checksum
+  (x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER), a feature Cellar does not support yet:
+  every state write fails with Error: Failed to save state [...] api error XAmzContentSHA256Mismatch
+  (reads are not affected). The skip_s3_checksum backend option has no effect on this behaviour.
+  Until Cellar supports trailing checksums, disable them through the AWS SDK environment variable:
+  
+  export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
 ---
 
 # clevercloud Provider
@@ -100,6 +132,46 @@ resource "clevercloud_nodejs" "my_app" {
 Where:
 - `USER` is the GitHub username of the person who created the token
 - `PAT_TOKEN` is the Personal Access Token generated in the previous step
+
+## Store the Terraform state on Cellar
+
+A [Cellar](https://www.clever.cloud/developers/doc/addons/cellar/) bucket can store your Terraform state through the [S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3). The backend must exist before `terraform init`, so use a Cellar add-on and a bucket created beforehand (from the [Console](https://console.clever-cloud.com/) or the CLI):
+
+```terraform
+terraform {
+  backend "s3" {
+    bucket = "my-terraform-state-bucket"
+    key    = "my-project.tfstate"
+    region = "us-east-1"
+    endpoints = {
+      s3 = "https://cellar-c2.services.clever-cloud.com"
+    }
+
+    use_path_style              = true
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+  }
+}
+```
+
+Credentials are read from the standard AWS environment variables, filled with the Cellar add-on ones:
+
+```bash
+export AWS_ACCESS_KEY_ID="$CELLAR_ADDON_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$CELLAR_ADDON_KEY_SECRET"
+```
+
+~> Recent Terraform versions upload the state with a trailing checksum
+(`x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`), a feature Cellar does not support yet:
+every state write fails with `Error: Failed to save state [...] api error XAmzContentSHA256Mismatch`
+(reads are not affected). The `skip_s3_checksum` backend option has no effect on this behaviour.
+Until Cellar supports trailing checksums, disable them through the AWS SDK environment variable:
+
+```bash
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+```
 
 
 

--- a/pkg/provider/impl/provider.md
+++ b/pkg/provider/impl/provider.md
@@ -53,3 +53,43 @@ resource "clevercloud_nodejs" "my_app" {
 Where:
 - `USER` is the GitHub username of the person who created the token
 - `PAT_TOKEN` is the Personal Access Token generated in the previous step
+
+## Store the Terraform state on Cellar
+
+A [Cellar](https://www.clever.cloud/developers/doc/addons/cellar/) bucket can store your Terraform state through the [S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3). The backend must exist before `terraform init`, so use a Cellar add-on and a bucket created beforehand (from the [Console](https://console.clever-cloud.com/) or the CLI):
+
+```terraform
+terraform {
+  backend "s3" {
+    bucket = "my-terraform-state-bucket"
+    key    = "my-project.tfstate"
+    region = "us-east-1"
+    endpoints = {
+      s3 = "https://cellar-c2.services.clever-cloud.com"
+    }
+
+    use_path_style              = true
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+  }
+}
+```
+
+Credentials are read from the standard AWS environment variables, filled with the Cellar add-on ones:
+
+```bash
+export AWS_ACCESS_KEY_ID="$CELLAR_ADDON_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$CELLAR_ADDON_KEY_SECRET"
+```
+
+~> Recent Terraform versions upload the state with a trailing checksum
+(`x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`), a feature Cellar does not support yet:
+every state write fails with `Error: Failed to save state [...] api error XAmzContentSHA256Mismatch`
+(reads are not affected). The `skip_s3_checksum` backend option has no effect on this behaviour.
+Until Cellar supports trailing checksums, disable them through the AWS SDK environment variable:
+
+```bash
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+```


### PR DESCRIPTION
Refs #340

Documents, at the provider level (`docs/index.md`), how to store the Terraform state on a Cellar bucket through the S3 backend — using a Cellar add-on and bucket created beforehand (Console or CLI), since the backend must exist before `terraform init`. This is not tied to the `clevercloud_cellar` resource, hence the placement in the provider index rather than the resource page.

## Diagnosis summary (reproduced on cellar-c2, Terraform 1.15.8)

Recent Terraform versions embed an aws-sdk-go-v2 whose data-integrity defaults (`RequestChecksumCalculation = WHEN_SUPPORTED`) make every `PutObject` use a chunked upload with a trailing checksum:

```
content-encoding:      aws-chunked
x-amz-content-sha256:  STREAMING-UNSIGNED-PAYLOAD-TRAILER
x-amz-trailer:         x-amz-checksum-crc32
```

Cellar's Ceph RGW rejects this encoding with `400 XAmzContentSHA256Mismatch`, so state reads work but every state write fails. The `skip_s3_checksum` backend option has no effect (tested both ways: `true` → crc32 trailer, `false` → sha256 trailer, both rejected).

The documented workaround, verified end-to-end (init/apply/state push):

```bash
export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
```

The provider itself is not affected (`cellar_bucket` uses minio-go, not aws-sdk-go-v2).