### PR TITLE
fix(postgresql,mongodb): populate feature defaults in Read to prevent force-replace on import

### DIFF
--- a/pkg/resources/database/mongodb/crud.go
+++ b/pkg/resources/database/mongodb/crud.go
@@ -54,48 +54,24 @@ func (r *ResourceMongoDB) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	mg.ID = pkg.FromStr(res.Payload().RealID)
-	mg.CreationDate = pkg.FromI(res.Payload().CreationDate)
-	mg.Plan = pkg.FromStr(res.Payload().Plan.Slug)
+	createdMg := res.Payload()
+	mg.ID = pkg.FromStr(createdMg.RealID)
+	r.readFromAddon(&mg, *createdMg)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, mg)...)
 
-	mgInfoRes := tmp.GetMongoDB(ctx, r.Client(), res.Payload().ID)
+	mgInfoRes := tmp.GetMongoDB(ctx, r.Client(), createdMg.ID)
 	if mgInfoRes.HasError() {
 		resp.Diagnostics.AddError("failed to get MongoDB connection infos", mgInfoRes.Error().Error())
 		return
 	}
 
-	addonMG := mgInfoRes.Payload()
-	tflog.Debug(ctx, "API response", map[string]any{
-		"payload": fmt.Sprintf("%+v", addonMG),
-	})
-	mg.Host = pkg.FromStr(addonMG.Host)
-	mg.Port = pkg.FromI(int64(addonMG.Port))
-	mg.User = pkg.FromStr(addonMG.User)
-	mg.Password = pkg.FromStr(addonMG.Password)
-	mg.Database = pkg.FromStr(addonMG.Database)
-	mg.Uri = pkg.FromStr(addonMG.Uri())
-
-	if mg.Encryption.IsUnknown() {
-		mg.Encryption = pkg.FromBool(false)
-	}
-	if mg.DirectHostOnly.IsUnknown() {
-		mg.DirectHostOnly = pkg.FromBool(false)
-	}
-	for _, feature := range addonMG.Features {
-		switch feature.Name {
-		case "encryption":
-			mg.Encryption = pkg.FromBool(feature.Enabled)
-		case "direct-host-only":
-			mg.DirectHostOnly = pkg.FromBool(feature.Enabled)
-		}
-	}
+	r.readFromAPI(&mg, *mgInfoRes.Payload())
 
 	addon.SyncNetworkGroups(
 		ctx,
 		r,
-		res.Payload().ID,
+		createdMg.ID,
 		mg.Networkgroups,
 		&mg.Networkgroups,
 		&resp.Diagnostics,
@@ -147,33 +123,41 @@ func (r *ResourceMongoDB) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 	addonInfo := addonRes.Payload()
 
-	tflog.Debug(ctx, "STATE", map[string]any{"mg": mg})
-	tflog.Debug(ctx, "API", map[string]any{"mg": addonMG})
-	mg.ID = pkg.FromStr(addonInfo.RealID)
-	mg.Name = pkg.FromStr(addonInfo.Name)
-	mg.Region = pkg.FromStr(addonInfo.Region)
-	mg.Plan = pkg.FromStr(addonInfo.Plan.Slug)
-	mg.CreationDate = pkg.FromI(addonInfo.CreationDate)
-	mg.Host = pkg.FromStr(addonMG.Host)
-	mg.Port = pkg.FromI(int64(addonMG.Port))
-	mg.User = pkg.FromStr(addonMG.User)
-	mg.Password = pkg.FromStr(addonMG.Password)
-	mg.Database = pkg.FromStr(addonMG.Database)
-	mg.Uri = pkg.FromStr(addonMG.Uri())
-
-	for _, feature := range addonMG.Features {
-		switch feature.Name {
-		case "encryption":
-			mg.Encryption = pkg.FromBool(feature.Enabled)
-		case "direct-host-only":
-			mg.DirectHostOnly = pkg.FromBool(feature.Enabled)
-		}
-	}
+	r.readFromAddon(&mg, *addonInfo)
+	r.readFromAPI(&mg, *addonMG)
 
 	mg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonId, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, mg)...)
+}
 
-	diags := resp.State.Set(ctx, mg)
-	resp.Diagnostics.Append(diags...)
+func (r *ResourceMongoDB) readFromAddon(state *MongoDB, addon tmp.AddonResponse) {
+	state.Name = pkg.FromStr(addon.Name)
+	state.Plan = pkg.FromStr(addon.Plan.Slug)
+	state.Region = pkg.FromStr(addon.Region)
+	state.CreationDate = pkg.FromI(addon.CreationDate)
+}
+
+func (r *ResourceMongoDB) readFromAPI(state *MongoDB, mg tmp.MongoDB) {
+	state.Host = pkg.FromStr(mg.Host)
+	state.Port = pkg.FromI(int64(mg.Port))
+	state.User = pkg.FromStr(mg.User)
+	state.Password = pkg.FromStr(mg.Password)
+	state.Database = pkg.FromStr(mg.Database)
+	state.Uri = pkg.FromStr(mg.Uri())
+
+	// Initialize to defaults so attributes are never null in state after import.
+	// The features loop below overrides with actual API values if present.
+	state.Encryption = pkg.FromBool(false)
+	state.DirectHostOnly = pkg.FromBool(false)
+
+	for _, feature := range mg.Features {
+		switch feature.Name {
+		case "encryption":
+			state.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			state.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		}
+	}
 }
 
 // Update resource

--- a/pkg/resources/database/mongodb/mongodb_test.go
+++ b/pkg/resources/database/mongodb/mongodb_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tests"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
@@ -88,6 +90,82 @@ func TestAccMongoDB_RefreshDeleted(t *testing.T) {
 				RefreshState: true,
 				// plan should contain database re-creation
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccMongoDB_Import tests that importing a MongoDB addon doesn't trigger
+// a force-replace on the next plan.
+// Same class of bug as MySQL issue #399: feature attributes remain null in state
+// after import because Read doesn't populate them when the API omits features.
+func TestAccMongoDB_Import(t *testing.T) {
+	t.Parallel()
+	cc := client.New(client.WithAutoOauthConfig())
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-mg-import")
+	fullName := fmt.Sprintf("clevercloud_mongodb.%s", rName)
+
+	var addonID string
+	var realID string
+
+	t.Cleanup(func() {
+		if addonID != "" {
+			tmp.DeleteAddon(context.Background(), cc, tests.ORGANISATION, addonID)
+		}
+	})
+
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	mgBlock := helper.NewRessource(
+		"clevercloud_mongodb",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"plan":   "xs_med",
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					addonsProvidersRes := tmp.GetAddonsProviders(ctx, cc)
+					if addonsProvidersRes.HasError() {
+						t.Fatalf("failed to get addon providers: %s", addonsProvidersRes.Error())
+					}
+					prov := pkg.LookupAddonProvider(*addonsProvidersRes.Payload(), "mongodb-addon")
+					plan := pkg.LookupProviderPlan(prov, "xs_med")
+					if plan == nil {
+						t.Fatal("failed to find xs_med plan for mongodb-addon")
+					}
+
+					res := tmp.CreateAddon(ctx, cc, tests.ORGANISATION, tmp.AddonRequest{
+						Name:       rName,
+						Plan:       plan.ID,
+						ProviderID: "mongodb-addon",
+						Region:     "par",
+						Options:    map[string]string{},
+					})
+					if res.HasError() {
+						t.Fatalf("failed to create mongodb addon: %s", res.Error())
+					}
+					addonID = res.Payload().ID
+					realID = res.Payload().RealID
+				},
+				Config:             providerBlock.Append(mgBlock).String(),
+				ResourceName:       fullName,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
+					return realID, nil
+				},
+			},
+			{
+				Config:   providerBlock.Append(mgBlock).String(),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -174,8 +174,7 @@ func (r *ResourcePostgreSQL) Create(ctx context.Context, req resource.CreateRequ
 	createdPg := res.Payload()
 
 	pg.ID = pkg.FromStr(createdPg.RealID)
-	pg.CreationDate = pkg.FromI(createdPg.CreationDate)
-	pg.Plan = pkg.FromStr(createdPg.Plan.Slug)
+	r.readFromAddon(&pg, *createdPg)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, pg)...)
 
@@ -184,35 +183,10 @@ func (r *ResourcePostgreSQL) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("failed to get postgres connection infos", pgInfoRes.Error().Error())
 		return
 	}
+
+	r.readFromAPI(&pg, *pgInfoRes.Payload())
+
 	addonPG := pgInfoRes.Payload()
-
-	tflog.Debug(ctx, "API response", map[string]any{
-		"payload": fmt.Sprintf("%+v", addonPG),
-	})
-	pg.Host = pkg.FromStr(addonPG.Host)
-	pg.Port = pkg.FromI(int64(addonPG.Port))
-	pg.Database = pkg.FromStr(addonPG.Database)
-	pg.User = pkg.FromStr(addonPG.User)
-	pg.Password = pkg.FromStr(addonPG.Password)
-	pg.Version = pkg.FromStr(addonPG.Version)
-	pg.Uri = pkg.FromStr(addonPG.Uri())
-
-	if pg.Encryption.IsUnknown() {
-		pg.Encryption = pkg.FromBool(false)
-	}
-	if pg.DirectHostOnly.IsUnknown() {
-		pg.DirectHostOnly = pkg.FromBool(false)
-	}
-
-	for _, option := range addonPG.Features {
-		switch option.Name {
-		case "encryption":
-			pg.Encryption = pkg.FromBool(option.Enabled)
-		case "direct-host-only":
-			pg.DirectHostOnly = pkg.FromBool(option.Enabled)
-		}
-	}
-
 	if plan.IsDedicated() {
 		locale, err := getLocaleFromDatabase(
 			ctx,
@@ -277,9 +251,7 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 	} else if addonRes.HasError() {
 		resp.Diagnostics.AddError("failed to get Postgres resource", addonRes.Error().Error())
 	} else {
-		addon := addonRes.Payload()
-		pg.Name = pkg.FromStr(addon.Name)
-		pg.CreationDate = pkg.FromI(addon.CreationDate)
+		r.readFromAddon(&pg, *addonRes.Payload())
 	}
 
 	addonPGRes := tmp.GetPostgreSQL(ctx, r.Client(), addonID)
@@ -295,28 +267,7 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 			return
 		}
 
-		pg.Plan = pkg.FromStr(addonPG.Plan)
-		pg.Region = pkg.FromStr(addonPG.Zone)
-		pg.Host = pkg.FromStr(addonPG.Host)
-		pg.Port = pkg.FromI(int64(addonPG.Port))
-		pg.Database = pkg.FromStr(addonPG.Database)
-		pg.User = pkg.FromStr(addonPG.User)
-		pg.Password = pkg.FromStr(addonPG.Password)
-		pg.Version = pkg.FromStr(addonPG.Version)
-		pg.Uri = pkg.FromStr(addonPG.Uri())
-
-		for _, feature := range addonPG.Features {
-			switch feature.Name {
-			case "do-backup":
-				pg.Backup = pkg.FromBool(feature.Enabled)
-			case "encryption":
-				pg.Encryption = pkg.FromBool(feature.Enabled)
-			case "direct-host-only":
-				pg.DirectHostOnly = pkg.FromBool(feature.Enabled)
-				// Note: locale feature only indicates if locale support is enabled, not the actual locale value
-				// We retrieve the actual locale value by connecting to the database
-			}
-		}
+		r.readFromAPI(&pg, *addonPG)
 	}
 
 	// Retrieve the actual locale value from the database by querying LC_COLLATE
@@ -339,6 +290,40 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 
 	pg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonID, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, pg)...)
+}
+
+func (r *ResourcePostgreSQL) readFromAddon(state *PostgreSQL, addon tmp.AddonResponse) {
+	state.Name = pkg.FromStr(addon.Name)
+	state.Plan = pkg.FromStr(addon.Plan.Slug)
+	state.Region = pkg.FromStr(addon.Region)
+	state.CreationDate = pkg.FromI(addon.CreationDate)
+}
+
+func (r *ResourcePostgreSQL) readFromAPI(state *PostgreSQL, pg tmp.PostgreSQL) {
+	state.Host = pkg.FromStr(pg.Host)
+	state.Port = pkg.FromI(int64(pg.Port))
+	state.Database = pkg.FromStr(pg.Database)
+	state.User = pkg.FromStr(pg.User)
+	state.Password = pkg.FromStr(pg.Password)
+	state.Version = pkg.FromStr(pg.Version)
+	state.Uri = pkg.FromStr(pg.Uri())
+
+	// Initialize to defaults so attributes are never null in state after import.
+	// The features loop below overrides with actual API values if present.
+	state.Backup = pkg.FromBool(true)
+	state.Encryption = pkg.FromBool(false)
+	state.DirectHostOnly = pkg.FromBool(false)
+
+	for _, feature := range pg.Features {
+		switch feature.Name {
+		case "do-backup":
+			state.Backup = pkg.FromBool(feature.Enabled)
+		case "encryption":
+			state.Encryption = pkg.FromBool(feature.Enabled)
+		case "direct-host-only":
+			state.DirectHostOnly = pkg.FromBool(feature.Enabled)
+		}
+	}
 }
 
 func (r *ResourcePostgreSQL) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/pkg/resources/database/postgresql/postgresql_test.go
+++ b/pkg/resources/database/postgresql/postgresql_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/tests"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
@@ -325,5 +327,82 @@ func TestAccPostgreSQL_LocaleCreate(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("locale"), knownvalue.StringExact("fr_FR")),
 			},
 		}},
+	})
+}
+
+// TestAccPostgreSQL_Import tests that importing a PostgreSQL addon doesn't trigger
+// a force-replace on the next plan.
+// Same class of bug as MySQL issue #399: feature attributes remain null in state
+// after import because Read doesn't populate them when the API omits features.
+func TestAccPostgreSQL_Import(t *testing.T) {
+	t.Parallel()
+	cc := client.New(client.WithAutoOauthConfig())
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-pg-import")
+	fullName := fmt.Sprintf("clevercloud_postgresql.%s", rName)
+
+	var addonID string
+	var realID string
+
+	t.Cleanup(func() {
+		if addonID != "" {
+			tmp.DeleteAddon(context.Background(), cc, tests.ORGANISATION, addonID)
+		}
+	})
+
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
+	pgBlock := helper.NewRessource(
+		"clevercloud_postgresql",
+		rName,
+		helper.SetKeyValues(map[string]any{
+			"name":   rName,
+			"region": "par",
+			"plan":   "xs_sml",
+			"backup": true,
+		}))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					addonsProvidersRes := tmp.GetAddonsProviders(ctx, cc)
+					if addonsProvidersRes.HasError() {
+						t.Fatalf("failed to get addon providers: %s", addonsProvidersRes.Error())
+					}
+					prov := pkg.LookupAddonProvider(*addonsProvidersRes.Payload(), "postgresql-addon")
+					plan := pkg.LookupProviderPlan(prov, "xs_sml")
+					if plan == nil {
+						t.Fatal("failed to find xs_sml plan for postgresql-addon")
+					}
+
+					res := tmp.CreateAddon(ctx, cc, tests.ORGANISATION, tmp.AddonRequest{
+						Name:       rName,
+						Plan:       plan.ID,
+						ProviderID: "postgresql-addon",
+						Region:     "par",
+						Options:    map[string]string{"do-backup": "true"},
+					})
+					if res.HasError() {
+						t.Fatalf("failed to create postgresql addon: %s", res.Error())
+					}
+					addonID = res.Payload().ID
+					realID = res.Payload().RealID
+				},
+				Config:             providerBlock.Append(pgBlock).String(),
+				ResourceName:       fullName,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
+					return realID, nil
+				},
+			},
+			{
+				Config:   providerBlock.Append(pgBlock).String(),
+				PlanOnly: true,
+			},
+		},
 	})
 }


### PR DESCRIPTION
Refs #399 — same class of bug as the MySQL case fixed in #400, applied to PostgreSQL and MongoDB.

The `Read` method of both resources doesn't initialise `backup`, `encryption` and `direct_host_only` before iterating over the API features. When the API omits a feature (shared plans), the attribute stays `null` in state after `terraform import`, and the `Optional+Computed(+Default)+RequiresReplace` schema shape turns that into a destroy/recreate on the next plan.

Mirrors the #400 fix: extract `readFromAddon`/`readFromAPI` methods (à la Elasticsearch and MySQL) so Create and Read share the same state-population logic with proper defaults, and add `TestAccPostgreSQL_Import` / `TestAccMongoDB_Import` acceptance tests.

Rebased on current master; both acceptance tests **pass against the real API** (PostgreSQL 38s, MongoDB 12s).

Note for reviewers: #405 (Codec migration) touches the same Read loops with an empty seed map (`absent → preserve` semantics) — it will need to seed these defaults when rebased on top of this fix, as it already does for MySQL.