### PR TITLE
ci: update all GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           release-type: go
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/doc_sync.yml
+++ b/.github/workflows/doc_sync.yml
@@ -18,13 +18,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
-            go-version: '1.24'
+            go-version-file: 'go.mod'
       - name: Get dependencies
         run: go mod download
 
@@ -53,7 +53,7 @@ jobs:
       - name: Commit docs update
         if: |
           failure()
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "docs: auto-update documentations"
           file_pattern: 'docs/'

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Block Fixup Commits
       uses: 13rac1/block-fixup-merge-action@v2.0.0
   conventional-commit:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: webiny/action-conventional-commits@v1.3.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
     # Provide a Terraform CLI on PATH so tests don't trigger hc-install's
     # GPG-verified download (HashiCorp's signing key periodically expires).
     - name: Setup Terraform
@@ -24,11 +24,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,23 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,5 +17,5 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.3"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
 

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -31,11 +31,11 @@ jobs:
           - software
           - kubernetes
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
     - name: Setup Terraform
       id: setup-terraform
       uses: hashicorp/setup-terraform@v4
@@ -55,11 +55,11 @@ jobs:
     needs: acceptance
     if: ${{ always() }} # run even if acceptance job fail
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
     - name: Sweepers
       if: always()
       run: make sweep


### PR DESCRIPTION
GitHub [deprecates Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); the release workflow was even running `goreleaser-action@v2` (Node 16 era). This updates every action to its latest major (all Node 24 runtimes):

| Action | Before | After |
|---|---|---|
| actions/checkout | v3 / v4 | v7 |
| actions/setup-go | v5 | v7 |
| goreleaser/goreleaser-action | v2 | v7 (`version: "~> v2"`) |
| crazy-max/ghaction-import-gpg | v5.2.0 | v7 |
| googleapis/release-please-action | v4 | v5 |
| stefanzweifel/git-auto-commit-action | v5 | v7 |
| google/osv-scanner-action | v2.3.3 | v2.5.0 |

Already at latest, unchanged: `hashicorp/setup-terraform@v4`, `golangci/golangci-lint-action@v9`, `13rac1/block-fixup-merge-action@v2.0.0`, `webiny/action-conventional-commits@v1.3.0`.

Breaking-change review done for each major bump: they are all "Node 24 runtime" only, except goreleaser-action v6 which requires GoReleaser v2 — `.goreleaser.yml` is already `version: 2` and the workflow already uses `release --clean`, so pinning `version: "~> v2"` is safe. `setup-go` now reads the Go version from `go.mod` (`go-version-file`) instead of hardcoded values that had drifted (`1.24` in release/doc_sync vs `1.25` elsewhere vs `1.25.0` in go.mod).

**Go dependencies**: nothing to bump — `go list -u -m all` reports every module already at its latest minor/patch.