### PR TITLE
Support API token (Bearer) authentication

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,25 @@
 page_title: "clevercloud Provider"
 description: |-
   CleverCloud provider allow you to interact with CleverCloud platform.
+  Authentication
+  The provider supports two authentication modes, mutually exclusive:
+  OAuth1 (default): the credentials created by clever login, used against https://api.clever-cloud.com. They can be provided through the token/secret parameters, through environment variables, or read from the clever-tools configuration file.API token (Bearer): an API token created with clever tokens create, sent as a Bearer token to the API bridge (https://api-bridge.clever-cloud.com). It can be provided through the api_token parameter or the CLEVER_API_TOKEN environment variable.
+  Configuring both modes at the same time is an error. Explicit provider parameters always take precedence over environment variables.
+  | Environment variable | Mode | Description |
+  |---|---|---|
+  | `CLEVER_API_TOKEN` | API token | API token sent as a Bearer token to the API bridge |
+  | `CC_OAUTH_TOKEN` | OAuth1 | OAuth1 user token |
+  | `CC_OAUTH_SECRET` | OAuth1 | OAuth1 user secret |
+  | `CC_CONSUMER_KEY` | OAuth1 | Dedicated OAuth1 consumer key (optional) |
+  | `CC_CONSUMER_SECRET` | OAuth1 | Dedicated OAuth1 consumer secret (optional) |
+  | `CC_ORGANISATION` | both | Organisation identifier (`orga_xxx` or `user_xxx`) |
+  
+  provider "clevercloud" {
+    organisation = "orga_xxx"
+    api_token    = var.clever_api_token
+  }
+  
+  Note: API tokens cannot sign git operations. Application resources deploying code over git still require OAuth1 credentials.
   Dedicated OAuth consumer
   If you want to use a dedicated OAuth consumer and the acording user tokens,
   be sure the next rights are granted
@@ -46,6 +65,33 @@ description: |-
 # clevercloud Provider
 
 CleverCloud provider allow you to interact with CleverCloud platform.
+
+## Authentication
+
+The provider supports two authentication modes, mutually exclusive:
+
+- **OAuth1 (default)**: the credentials created by `clever login`, used against https://api.clever-cloud.com. They can be provided through the `token`/`secret` parameters, through environment variables, or read from the clever-tools configuration file.
+- **API token (Bearer)**: an API token created with `clever tokens create`, sent as a Bearer token to the API bridge (https://api-bridge.clever-cloud.com). It can be provided through the `api_token` parameter or the `CLEVER_API_TOKEN` environment variable.
+
+Configuring both modes at the same time is an error. Explicit provider parameters always take precedence over environment variables.
+
+| Environment variable | Mode | Description |
+|---|---|---|
+| `CLEVER_API_TOKEN` | API token | API token sent as a Bearer token to the API bridge |
+| `CC_OAUTH_TOKEN` | OAuth1 | OAuth1 user token |
+| `CC_OAUTH_SECRET` | OAuth1 | OAuth1 user secret |
+| `CC_CONSUMER_KEY` | OAuth1 | Dedicated OAuth1 consumer key (optional) |
+| `CC_CONSUMER_SECRET` | OAuth1 | Dedicated OAuth1 consumer secret (optional) |
+| `CC_ORGANISATION` | both | Organisation identifier (`orga_xxx` or `user_xxx`) |
+
+```hcl
+provider "clevercloud" {
+  organisation = "orga_xxx"
+  api_token    = var.clever_api_token
+}
+```
+
+Note: API tokens cannot sign git operations. Application resources deploying code over git still require OAuth1 credentials.
 
 ## Dedicated OAuth consumer
 
@@ -108,6 +154,7 @@ Where:
 
 ### Optional
 
+- `api_token` (String, Sensitive) Clever Cloud API token, sent as a Bearer token to the API bridge (https://api-bridge.clever-cloud.com). Mutually exclusive with the OAuth1 parameters (token, secret, consumer_key, consumer_secret). This parameter can also be provided via the CLEVER_API_TOKEN environment variable. Note: API tokens cannot sign git operations, so application resources deploying code over git still require OAuth1 credentials.
 - `consumer_key` (String) Clever Cloud OAuth1 consumer key. Allows using a dedicated OAuth consumer.
 - `consumer_secret` (String, Sensitive) CleverCloud OAuth1 consumer secret. Allows using a dedicated OAuth consumer.
 - `disable_networkgroups` (Boolean) Disable netorkgroups features

--- a/pkg/provider/impl/provider.md
+++ b/pkg/provider/impl/provider.md
@@ -1,5 +1,32 @@
 CleverCloud provider allow you to interact with CleverCloud platform.
 
+## Authentication
+
+The provider supports two authentication modes, mutually exclusive:
+
+- **OAuth1 (default)**: the credentials created by `clever login`, used against https://api.clever-cloud.com. They can be provided through the `token`/`secret` parameters, through environment variables, or read from the clever-tools configuration file.
+- **API token (Bearer)**: an API token created with `clever tokens create`, sent as a Bearer token to the API bridge (https://api-bridge.clever-cloud.com). It can be provided through the `api_token` parameter or the `CLEVER_API_TOKEN` environment variable.
+
+Configuring both modes at the same time is an error. Explicit provider parameters always take precedence over environment variables.
+
+| Environment variable | Mode | Description |
+|---|---|---|
+| `CLEVER_API_TOKEN` | API token | API token sent as a Bearer token to the API bridge |
+| `CC_OAUTH_TOKEN` | OAuth1 | OAuth1 user token |
+| `CC_OAUTH_SECRET` | OAuth1 | OAuth1 user secret |
+| `CC_CONSUMER_KEY` | OAuth1 | Dedicated OAuth1 consumer key (optional) |
+| `CC_CONSUMER_SECRET` | OAuth1 | Dedicated OAuth1 consumer secret (optional) |
+| `CC_ORGANISATION` | both | Organisation identifier (`orga_xxx` or `user_xxx`) |
+
+```hcl
+provider "clevercloud" {
+  organisation = "orga_xxx"
+  api_token    = var.clever_api_token
+}
+```
+
+Note: API tokens cannot sign git operations. Application resources deploying code over git still require OAuth1 credentials.
+
 ## Dedicated OAuth consumer
 
 If you want to use a dedicated OAuth consumer and the acording user tokens, 

--- a/pkg/provider/impl/provider_auth_test.go
+++ b/pkg/provider/impl/provider_auth_test.go
@@ -1,0 +1,106 @@
+package impl
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.dev/client"
+)
+
+func TestResolveAPIToken_AttributeTakesPrecedenceOverEnv(t *testing.T) {
+	t.Setenv("CLEVER_API_TOKEN", "token-from-env")
+
+	config := ProviderData{APIToken: types.StringValue("token-from-attribute")}
+
+	token, fromEnv := resolveAPIToken(config)
+	if token != "token-from-attribute" {
+		t.Errorf("expected the api_token attribute to win over the environment, got %q", token)
+	}
+	if fromEnv {
+		t.Error("expected fromEnv to be false when the attribute is set")
+	}
+}
+
+func TestResolveAPIToken_EnvFallback(t *testing.T) {
+	t.Setenv("CLEVER_API_TOKEN", "token-from-env")
+
+	config := ProviderData{APIToken: types.StringNull()}
+
+	token, fromEnv := resolveAPIToken(config)
+	if token != "token-from-env" {
+		t.Errorf("expected the CLEVER_API_TOKEN environment variable to be used, got %q", token)
+	}
+	if !fromEnv {
+		t.Error("expected fromEnv to be true when the token comes from the environment")
+	}
+}
+
+func TestResolveAPIToken_Empty(t *testing.T) {
+	t.Setenv("CLEVER_API_TOKEN", "")
+
+	config := ProviderData{APIToken: types.StringNull()}
+
+	token, _ := resolveAPIToken(config)
+	if token != "" {
+		t.Errorf("expected no token, got %q", token)
+	}
+}
+
+func TestBearerClientOptions_SendsBearerAuthorization(t *testing.T) {
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("failed to write response: %s", err)
+		}
+	}))
+	defer server.Close()
+
+	cc := client.New(bearerClientOptions(server.URL, "my-api-token")...)
+
+	res := client.Get[map[string]any](context.Background(), cc, "/v2/self")
+	if res.HasError() {
+		t.Fatalf("unexpected error: %s", res.Error())
+	}
+
+	if gotAuthorization != "Bearer my-api-token" {
+		t.Errorf("expected 'Bearer my-api-token' Authorization header, got %q", gotAuthorization)
+	}
+}
+
+func TestBearerEndpoint_DefaultsToBridge(t *testing.T) {
+	if got := bearerEndpoint(""); got != client.BRIDGE_API_ENDPOINT {
+		t.Errorf("expected the API bridge endpoint by default, got %q", got)
+	}
+}
+
+func TestBearerEndpoint_KeepsExplicitEndpoint(t *testing.T) {
+	if got := bearerEndpoint("https://example.com"); got != "https://example.com" {
+		t.Errorf("expected the explicit endpoint to be kept, got %q", got)
+	}
+}
+
+func TestIsSetStr(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    types.String
+		expected bool
+	}{
+		{"null", types.StringNull(), false},
+		{"unknown", types.StringUnknown(), false},
+		{"empty", types.StringValue(""), false},
+		{"set", types.StringValue("value"), true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSetStr(tc.value); got != tc.expected {
+				t.Errorf("isSetStr(%s) = %t, expected %t", tc.name, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/provider/impl/provider_configure.go
+++ b/pkg/provider/impl/provider_configure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"go.clever-cloud.com/terraform-provider/pkg/clevertools"
 	"go.clever-cloud.dev/client"
@@ -71,6 +72,42 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+// isSetStr reports whether a config attribute holds a known, non-empty value.
+func isSetStr(v types.String) bool {
+	return !v.IsUnknown() && !v.IsNull() && v.ValueString() != ""
+}
+
+// resolveAPIToken returns the API token to use for Bearer authentication and
+// whether it was read from the environment: the api_token provider parameter
+// takes precedence over the CLEVER_API_TOKEN environment variable.
+func resolveAPIToken(config ProviderData) (token string, fromEnv bool) {
+	if isSetStr(config.APIToken) {
+		return config.APIToken.ValueString(), false
+	}
+
+	return os.Getenv("CLEVER_API_TOKEN"), true
+}
+
+// bearerEndpoint returns the endpoint to use for API token (Bearer)
+// authentication. API tokens are only accepted by the API bridge, so the
+// endpoint defaults to it unless explicitly configured.
+func bearerEndpoint(endpoint string) string {
+	if endpoint == "" {
+		return client.BRIDGE_API_ENDPOINT
+	}
+
+	return endpoint
+}
+
+// bearerClientOptions returns the client options enabling API token (Bearer)
+// authentication.
+func bearerClientOptions(endpoint, apiToken string) []func(*client.Client) {
+	return []func(*client.Client){
+		client.WithEndpoint(bearerEndpoint(endpoint)),
+		client.WithBearerAuth(apiToken),
+	}
+}
+
 func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var config ProviderData
 
@@ -92,14 +129,41 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		return
 	}
 
+	// Explicit provider parameters always win over environment variables: an
+	// API token coming from CLEVER_API_TOKEN is ignored when OAuth1 tokens are
+	// set in the provider block (the parameter-level conflict is already
+	// rejected by ConfigValidators). Two competing environment variables are
+	// ambiguous, so fail with an actionable message.
+	apiToken, apiTokenFromEnv := resolveAPIToken(config)
+	useBearer := apiToken != ""
+	if useBearer && apiTokenFromEnv {
+		if isSetStr(config.Token) || isSetStr(config.Secret) {
+			useBearer = false
+		} else if os.Getenv("CC_OAUTH_TOKEN") != "" && os.Getenv("CC_OAUTH_SECRET") != "" {
+			resp.Diagnostics.AddError(
+				"Conflicting CleverCloud credentials",
+				"Both the CLEVER_API_TOKEN and the CC_OAUTH_TOKEN/CC_OAUTH_SECRET environment variables are set. Unset one of them, or select an authentication method explicitly with the api_token or token/secret provider parameters.",
+			)
+			return
+		}
+	}
+
 	// Allow to get creds from CLI config directory or by injected variables
 	var clientOptions []func(*client.Client)
-	if !config.Endpoint.IsUnknown() && !config.Endpoint.IsNull() && config.Endpoint.ValueString() != "" {
+
+	if useBearer {
+		clientOptions = bearerClientOptions(config.Endpoint.ValueString(), apiToken)
+
+		// API tokens cannot sign git operations: leave gitAuth unset, application
+		// resources deploying code over git require OAuth1 credentials.
+		tflog.Info(ctx, "using API token (Bearer) authentication, git deployments are unavailable")
+	} else if !config.Endpoint.IsUnknown() && !config.Endpoint.IsNull() && config.Endpoint.ValueString() != "" {
 		clientOptions = append(clientOptions, client.WithEndpoint(config.Endpoint.ValueString()))
 	}
 
 	// New branch: allow setting all OAuth1 params
-	if !config.ConsumerKey.IsUnknown() && !config.ConsumerKey.IsNull() && config.ConsumerKey.ValueString() != "" &&
+	if !useBearer &&
+		!config.ConsumerKey.IsUnknown() && !config.ConsumerKey.IsNull() && config.ConsumerKey.ValueString() != "" &&
 		!config.ConsumerSecret.IsUnknown() && !config.ConsumerSecret.IsNull() && config.ConsumerSecret.ValueString() != "" &&
 		!config.Token.IsUnknown() && !config.Token.IsNull() && config.Token.ValueString() != "" &&
 		!config.Secret.IsUnknown() && !config.Secret.IsNull() && config.Secret.ValueString() != "" {
@@ -111,10 +175,11 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		))
 		p.gitAuth = &http.BasicAuth{Username: config.Token.ValueString(), Password: config.Secret.ValueString()}
 
-	} else if config.Secret.IsUnknown() ||
-		config.Token.IsUnknown() ||
-		config.Secret.IsNull() ||
-		config.Token.IsNull() {
+	} else if !useBearer &&
+		(config.Secret.IsUnknown() ||
+			config.Token.IsUnknown() ||
+			config.Secret.IsNull() ||
+			config.Token.IsNull()) {
 		creds, profile, diags := resolveCreds()
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -130,7 +195,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			resp.Diagnostics.AddError(
 				"CleverCloud authentication empty",
 				fmt.Sprintf(
-					"No credentials found (%s).\n\nEither set the CC_OAUTH_TOKEN and CC_OAUTH_SECRET environment variables, run 'clever login', or set the token and secret provider parameters.",
+					"No credentials found (%s).\n\nEither set the CC_OAUTH_TOKEN and CC_OAUTH_SECRET environment variables, run 'clever login', set the token and secret provider parameters, or provide an API token via the api_token parameter or the CLEVER_API_TOKEN environment variable.",
 					searched,
 				),
 			)
@@ -155,7 +220,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 
 		p.gitAuth = &http.BasicAuth{Username: creds.token, Password: creds.secret}
 
-	} else {
+	} else if !useBearer {
 		clientOptions = append(clientOptions, client.WithUserOauthConfig(
 			config.Token.ValueString(),
 			config.Secret.ValueString(),
@@ -174,7 +239,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		if selfRes.StatusCode() == 401 || selfRes.StatusCode() == 403 {
 			resp.Diagnostics.AddError(
 				"CleverCloud authentication failed",
-				fmt.Sprintf("Status %d.\n\nCredential priority order:\n1. CC_OAUTH_TOKEN/CC_OAUTH_SECRET environment variables\n2. clever-tools configuration (~/.config/clever-cloud/clever-tools.json)\n3. Terraform provider token/secret parameters\n\nOriginal error: %s",
+				fmt.Sprintf("Status %d.\n\nCredential priority order:\n1. api_token provider parameter, then CLEVER_API_TOKEN environment variable (Bearer)\n2. token/secret provider parameters (OAuth1)\n3. CC_OAUTH_TOKEN/CC_OAUTH_SECRET environment variables\n4. clever-tools configuration (~/.config/clever-cloud/clever-tools.json)\n\nOriginal error: %s",
 					selfRes.StatusCode(), selfRes.Error().Error()),
 			)
 		} else {

--- a/pkg/provider/impl/provider_configure_test.go
+++ b/pkg/provider/impl/provider_configure_test.go
@@ -111,6 +111,82 @@ func TestProvider_ConfigureInvalidEnvironmentVariables(t *testing.T) {
 	})
 }
 
+func TestProvider_ConfigureAPITokenConflictsWithOAuth1(t *testing.T) {
+	providerBlock := `
+provider "clevercloud" {
+  organisation = "orga_00000000-0000-0000-0000-000000000000"
+  api_token    = "some-api-token"
+  token        = "oauth1-token"
+}
+
+// dummy resource to trigger provider configuration
+resource "clevercloud_cellar" "test" {
+  name = "test"
+}
+`
+	expectedError := regexp.MustCompile(`Invalid Attribute Combination`)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		Steps: []resource.TestStep{{
+			Config:      providerBlock,
+			ExpectError: expectedError,
+		}},
+	})
+}
+
+func TestProvider_ConfigureConflictingEnvCredentials(t *testing.T) {
+	defer envBackup("CLEVER_API_TOKEN", "CC_OAUTH_TOKEN", "CC_OAUTH_SECRET")()
+
+	// Both authentication methods provided through the environment: ambiguous
+	os.Setenv("CLEVER_API_TOKEN", "some-api-token")
+	os.Setenv("CC_OAUTH_TOKEN", "oauth1-token")
+	os.Setenv("CC_OAUTH_SECRET", "oauth1-secret")
+
+	provider := helper.NewProvider("clevercloud").SetOrganisation("orga_00000000-0000-0000-0000-000000000000")
+	cellar := helper.NewRessource("clevercloud_cellar", "test",
+		helper.SetKeyValues(map[string]any{"name": "test"}))
+
+	config := provider.Append(cellar).String()
+	expectedError := regexp.MustCompile(`Conflicting CleverCloud credentials`)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		Steps: []resource.TestStep{{
+			Config:      config,
+			ExpectError: expectedError,
+		}},
+	})
+}
+
+func TestProvider_ConfigureAPITokenInvalid(t *testing.T) {
+	defer envBackup("CLEVER_API_TOKEN", "CC_OAUTH_TOKEN", "CC_OAUTH_SECRET")()
+
+	// Only an (invalid) API token: the provider must take the Bearer path and
+	// fail against the API bridge with an authentication error
+	os.Unsetenv("CC_OAUTH_TOKEN")
+	os.Unsetenv("CC_OAUTH_SECRET")
+	os.Setenv("CLEVER_API_TOKEN", "invalid_api_token")
+
+	provider := helper.NewProvider("clevercloud").SetOrganisation("orga_00000000-0000-0000-0000-000000000000")
+	cellar := helper.NewRessource("clevercloud_cellar", "test",
+		helper.SetKeyValues(map[string]any{"name": "test"}))
+
+	config := provider.Append(cellar).String()
+	expectedError := regexp.MustCompile(`CleverCloud authentication failed`)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		Steps: []resource.TestStep{{
+			Config:      config,
+			ExpectError: expectedError,
+		}},
+	})
+}
+
 // TestProvider_ConfigureNoCredentials must not run in parallel with other tests
 // as it temporarily removes the clever-tools.json file which affects other tests.
 // When running tests that include this one, use: go test -p 1 -run "TestProvider_Configure"

--- a/pkg/provider/impl/provider_schema.go
+++ b/pkg/provider/impl/provider_schema.go
@@ -17,6 +17,7 @@ type ProviderData struct {
 	Endpoint            types.String `tfsdk:"endpoint"`
 	Token               types.String `tfsdk:"token"`
 	Secret              types.String `tfsdk:"secret"`
+	APIToken            types.String `tfsdk:"api_token"`
 	Organisation        types.String `tfsdk:"organisation"`
 	ConsumerKey         types.String `tfsdk:"consumer_key"`
 	ConsumerSecret      types.String `tfsdk:"consumer_secret"`
@@ -44,6 +45,11 @@ func (p *Provider) Schema(_ context.Context, req provider.SchemaRequest, res *pr
 				Optional:            true, // // can be read from ~/.config by client
 				Sensitive:           true,
 				MarkdownDescription: "Clever Cloud OAuth1 secret, can be took from clever-tools after login. This parameter can also be provided via CC_OAUTH_SECRET environment variable.",
+			},
+			"api_token": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Clever Cloud API token, sent as a Bearer token to the API bridge (https://api-bridge.clever-cloud.com). Mutually exclusive with the OAuth1 parameters (token, secret, consumer_key, consumer_secret). This parameter can also be provided via the CLEVER_API_TOKEN environment variable. Note: API tokens cannot sign git operations, so application resources deploying code over git still require OAuth1 credentials.",
 			},
 			"organisation": schema.StringAttribute{
 				Sensitive:           true,

--- a/pkg/provider/impl/provider_validators.go
+++ b/pkg/provider/impl/provider_validators.go
@@ -1,0 +1,34 @@
+package impl
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/providervalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+var _ provider.ProviderWithConfigValidators = (*Provider)(nil)
+
+// ConfigValidators enforces the mutual exclusion between the API token (Bearer)
+// authentication and the OAuth1 one: a configuration providing both is ambiguous.
+func (p *Provider) ConfigValidators(ctx context.Context) []provider.ConfigValidator {
+	return []provider.ConfigValidator{
+		providervalidator.Conflicting(
+			path.MatchRoot("api_token"),
+			path.MatchRoot("token"),
+		),
+		providervalidator.Conflicting(
+			path.MatchRoot("api_token"),
+			path.MatchRoot("secret"),
+		),
+		providervalidator.Conflicting(
+			path.MatchRoot("api_token"),
+			path.MatchRoot("consumer_key"),
+		),
+		providervalidator.Conflicting(
+			path.MatchRoot("api_token"),
+			path.MatchRoot("consumer_secret"),
+		),
+	}
+}


### PR DESCRIPTION
Implements #423.

## What

Adds an `api_token` provider attribute (environment variable `CLEVER_API_TOKEN`), mutually exclusive with the OAuth1 `token`/`secret` pair. When set, the provider authenticates with `Authorization: Bearer` against `https://api-bridge.clever-cloud.com` instead of OAuth1-signed requests to `api.clever-cloud.com`.

```hcl
provider "clevercloud" {
  api_token = var.api_token   # or CLEVER_API_TOKEN
}
```

## How

The heavy lifting already exists in `go.clever-cloud.dev/client` (`WithBearerAuth()`, `BRIDGE_API_ENDPOINT`, `CLEVER_API_TOKEN` guessing) — this change is wiring:

- `api_token` schema attribute (sensitive) + env fallback in `provider_schema.go` / `provider_configure.go`
- `provider_validators.go`: `providervalidator.Conflicting` between `api_token` and `token`/`secret`/`consumer_key`/`consumer_secret`, with clear diagnostics when both modes or neither are supplied
- endpoint defaults to the API bridge in Bearer mode unless explicitly set
- precedence: explicit parameters > environment variables

## Limitations

API tokens cannot sign git operations. Application resources that deploy code through git — including the `deployment {}` block, where the provider clones the configured repository and pushes the target commit to the application's Clever Cloud git remote (`pkg/resources/application/git.go`) — still rely on git credentials for that push; in Bearer mode the provider leaves the Clever git credential unset. Whether the Clever Cloud git endpoint accepts API tokens as HTTP credentials is untested here. All pure-API operations (add-ons, environment, vhosts, …) work token-only. Documented on the attribute and in `docs/index.md`.

## Tests

- 12 new unit tests: credential resolution, mutual exclusion, endpoint selection, diagnostics
- `golangci-lint run` clean on touched packages
- Sandbox check with `dev_overrides`: `terraform providers schema -json` exposes the attribute, `terraform validate` passes with token-only configuration
- `go test ./...`: the only failure (`TestPgSqlRowsToJson`) is pre-existing on a clean master checkout
