### PR TITLE
fix(postgresql): pin explicit TLS semantics on the locale probe

### DIFF
--- a/pkg/resources/database/postgresql/crud.go
+++ b/pkg/resources/database/postgresql/crud.go
@@ -2,6 +2,7 @@ package postgresql
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources"
@@ -46,26 +49,82 @@ func (r *ResourcePostgreSQL) Infos(ctx context.Context, diags *diag.Diagnostics)
 	return r.infos
 }
 
-// getLocaleFromDatabase connects to the PostgreSQL database and retrieves the LC_COLLATE setting
-// which indicates the locale used when the database was created.
-// Returns the locale in format "en_GB" or empty string if unable to retrieve.
-// Retries connection up to 30 times with 2 second delay to handle database startup time.
-func getLocaleFromDatabase(ctx context.Context, host string, port int64, database, user, password string) (string, error) {
-	// Build DSN (Data Source Name) for PostgreSQL connection
+// localePgConfig builds the pgx connection configuration used to read the
+// locale. The intended semantics are the ones libpq gives to sslmode=require:
+// encrypt the connection without verifying the server certificate, because
+// Clever Cloud managed databases serve self-signed certificates. pgx diverges
+// from libpq here and escalates require to verify-ca whenever a root CA is
+// discoverable (sslrootcert, PGSSLROOTCERT or ~/.postgresql/root.crt), which
+// makes the connection fail on the self-signed certificate; enforce the
+// intended semantics with an explicit TLS configuration instead.
+func localePgConfig(host string, port int64, database, user, password string) (*pgx.ConnConfig, error) {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=require",
 		host, port, user, password, database)
 
-	var db *gorm.DB
-	var err error
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse database connection configuration: %w", err)
+	}
 
-	// Retry connection up to 30 times (60 seconds total) to allow database to start
+	cfg.TLSConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- libpq sslmode=require semantics: encrypt without certificate verification
+	cfg.Fallbacks = nil
+
+	return cfg, nil
+}
+
+// isRetryableLocaleError reports whether a connection error may resolve by
+// itself (database still starting up). Authentication and TLS failures are
+// permanent: retrying them only wastes the 30 x 5s retry budget.
+func isRetryableLocaleError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	for _, permanent := range []string{
+		"x509:",                          // TLS certificate verification
+		"tls:",                           // TLS handshake
+		"SQLSTATE 28",                    // invalid authorization (28000) / invalid password (28P01)
+		"password authentication failed", // in case the SQLSTATE is not surfaced
+	} {
+		if strings.Contains(msg, permanent) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// getLocaleFromDatabase connects to the PostgreSQL database and retrieves the LC_COLLATE setting
+// which indicates the locale used when the database was created.
+// Returns the locale in format "en_GB" or empty string if unable to retrieve.
+// Retries connection up to 30 times with 5 second delay to handle database startup time.
+func getLocaleFromDatabase(ctx context.Context, host string, port int64, database, user, password string) (string, error) {
+	cfg, err := localePgConfig(host, port, database, user, password)
+	if err != nil {
+		return "", err
+	}
+
+	var db *gorm.DB
+
+	// Retry connection up to 30 times to allow the database to start, but fail
+	// fast on permanent errors (bad credentials, TLS failure)
 	maxRetries := 30
 	for i := range maxRetries {
-		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
+		conn := stdlib.OpenDB(*cfg)
+		db, err = gorm.Open(postgres.New(postgres.Config{Conn: conn}), &gorm.Config{
 			Logger: logger.Default.LogMode(logger.Silent), // Silent mode to avoid logs
 		})
 		if err == nil {
 			break
+		}
+
+		if closeErr := conn.Close(); closeErr != nil {
+			tflog.Warn(ctx, "failed to close database connection", map[string]any{"error": closeErr.Error()})
+		}
+
+		if !isRetryableLocaleError(err) {
+			return "", fmt.Errorf("failed to connect to database: %w", err)
 		}
 
 		if i < maxRetries-1 {
@@ -271,21 +330,26 @@ func (r *ResourcePostgreSQL) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Retrieve the actual locale value from the database by querying LC_COLLATE
-	// This is necessary because the API doesn't return the locale value
-	locale, err := getLocaleFromDatabase(
-		ctx,
-		pg.Host.ValueString(),
-		pg.Port.ValueInt64(),
-		pg.Database.ValueString(),
-		pg.User.ValueString(),
-		pg.Password.ValueString(),
-	)
-	if err != nil {
-		// On shared/dev plans, the user doesn't have permission to query pg_database
-		// This is expected, so we just log a warning
-		tflog.Warn(ctx, "Failed to retrieve locale from database, using default", map[string]any{"error": err.Error()})
-	} else {
-		pg.Locale = pkg.FromStr(locale)
+	// This is necessary because the API doesn't return the locale value.
+	// The locale is fixed at database creation time (LC_COLLATE cannot change
+	// afterwards) and reading it requires a live connection to the database:
+	// only do so when the state does not carry it yet (import)
+	if pg.Locale.IsNull() || pg.Locale.IsUnknown() {
+		locale, err := getLocaleFromDatabase(
+			ctx,
+			pg.Host.ValueString(),
+			pg.Port.ValueInt64(),
+			pg.Database.ValueString(),
+			pg.User.ValueString(),
+			pg.Password.ValueString(),
+		)
+		if err != nil {
+			// On shared/dev plans, the user doesn't have permission to query pg_database
+			// This is expected, so we just log a warning
+			tflog.Warn(ctx, "Failed to retrieve locale from database, using default", map[string]any{"error": err.Error()})
+		} else {
+			pg.Locale = pkg.FromStr(locale)
+		}
 	}
 
 	pg.Networkgroups = resources.ReadNetworkGroups(ctx, r, addonID, &resp.Diagnostics)

--- a/pkg/resources/database/postgresql/locale_test.go
+++ b/pkg/resources/database/postgresql/locale_test.go
@@ -1,0 +1,120 @@
+package postgresql
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// selfSignedCertPEM writes a valid self-signed certificate to a temporary file
+// and returns its path, to simulate a root CA discoverable by pgx.
+func selfSignedCertPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %s", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "root.crt")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, certPEM, 0o600); err != nil {
+		t.Fatalf("failed to write certificate: %s", err)
+	}
+
+	return path
+}
+
+func TestLocalePgConfig_SkipsCertificateVerification(t *testing.T) {
+	cfg, err := localePgConfig("db.example.com", 5432, "mydb", "user", "password")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if cfg.TLSConfig == nil {
+		t.Fatal("expected a TLS configuration (encrypted connection), got nil")
+	}
+	if !cfg.TLSConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify: managed databases serve self-signed certificates")
+	}
+	if cfg.TLSConfig.VerifyPeerCertificate != nil {
+		t.Error("expected no custom certificate verification")
+	}
+	if len(cfg.Fallbacks) != 0 {
+		t.Errorf("expected no fallback configurations, got %d", len(cfg.Fallbacks))
+	}
+}
+
+// TestLocalePgConfig_IgnoresDiscoverableRootCA pins the regression behind the
+// 150 seconds lost per operation on dedicated plans: pgx escalates
+// sslmode=require to verify-ca when a root CA is discoverable through the
+// environment, which then rejects the self-signed server certificate.
+func TestLocalePgConfig_IgnoresDiscoverableRootCA(t *testing.T) {
+	t.Setenv("PGSSLROOTCERT", selfSignedCertPEM(t))
+
+	cfg, err := localePgConfig("db.example.com", 5432, "mydb", "user", "password")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if cfg.TLSConfig == nil {
+		t.Fatal("expected a TLS configuration (encrypted connection), got nil")
+	}
+	if !cfg.TLSConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify even with PGSSLROOTCERT set")
+	}
+	if cfg.TLSConfig.RootCAs != nil {
+		t.Error("expected the discovered root CA pool to be ignored")
+	}
+	if cfg.TLSConfig.VerifyPeerCertificate != nil {
+		t.Error("expected the verify-ca escalation to be neutralised")
+	}
+}
+
+func TestIsRetryableLocaleError(t *testing.T) {
+	testCases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"nil", nil, false},
+		{"x509 verification", errors.New("failed to connect: x509: certificate signed by unknown authority"), false},
+		{"tls handshake", errors.New("tls: handshake failure"), false},
+		{"invalid password", errors.New("failed SASL auth (FATAL: password authentication failed for user (SQLSTATE 28P01))"), false},
+		{"invalid authorization", errors.New("FATAL: role does not exist (SQLSTATE 28000)"), false},
+		{"connection refused", errors.New("dial tcp 10.0.0.1:5432: connect: connection refused"), true},
+		{"timeout", errors.New("dial tcp 10.0.0.1:5432: i/o timeout"), true},
+		{"dns", errors.New("lookup db.example.com: no such host"), true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableLocaleError(tc.err); got != tc.retryable {
+				t.Errorf("isRetryableLocaleError(%v) = %t, expected %t", tc.err, got, tc.retryable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #425.

## What

The locale probe (`getLocaleFromDatabase`) hands a plain `sslmode=require` DSN to GORM's pgx/v5-based driver with no explicit TLS configuration. pgx faithfully implements libpq's documented backwards-compatibility rule: when a root CA file is discoverable in the environment (`sslrootcert`, `PGSSLROOTCERT`, `~/.postgresql/root.crt`), `sslmode=require` silently escalates to `verify-ca` semantics. Clever Cloud add-ons serve self-signed certificates, so in such environments every probe fails its handshake and burns the whole retry budget (30 × 5 s ≈ 150 s) — on every Read regardless of plan, and as a hard failure on dedicated-plan creation.

## How

- Parse the DSN, then pin the TLS configuration to encrypt-without-verification and drop fallbacks. `sslmode=require` stays in the DSN — encryption is always on; the probe's TLS posture no longer depends on the operator's ambient libpq environment.
- Gate the Read-path probe on the locale actually being unknown: routine plan/refresh no longer opens a live connection; only import (locale absent from state), dedicated-plan creation (where the retry loop legitimately waits for the database to come up) and the one-shot v0→v1 state migration still do.

## Tests

`locale_test.go` (new, 120 lines): TLS pinning, retryable-error classification, Read-path gating. The assertions fail on master without the fix; `go test ./pkg/resources/database/postgresql/` and `go vet` clean.