### PR TITLE
fix(application): keep env vars declared in `environment` on refresh

### DIFF
--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -65,6 +65,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -104,6 +104,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -53,6 +53,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -118,6 +118,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -109,6 +109,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -46,6 +46,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -181,6 +181,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `gzip_types` (String) Set the mime types to compress (default: 'text/* application/json application/xml application/javascript image/svg+xml')
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `features` (Set of String) List of Rust features to enable during build
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -108,6 +108,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -111,6 +111,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -144,6 +144,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -106,6 +106,8 @@ environment = { for k, v in {
   VAR2 = var.optional_var
 } : k => v if v != null }
 ```
+
+**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.
 - `exposed_environment` (Map of String, Sensitive) Environment variables other linked applications will be able to use
 - `hooks` (Block, Optional) (see [below for nested schema](#nestedblock--hooks))
 - `integrations` (Attributes) Third-party integrations configuration (see [below for nested schema](#nestedatt--integrations))

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -101,4 +101,5 @@ func (r *ResourceDocker) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "docker", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceDotnet) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "dotnet", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/env_slot.go
+++ b/pkg/resources/application/env_slot.go
@@ -1,0 +1,26 @@
+package application
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	helpermaps "github.com/miton18/helper/maps"
+)
+
+// withholdUserManagedEnv hides from the runtime, hook and integration readers
+// every variable the practitioner declares in `environment`, so refresh cannot
+// move it to its dedicated attribute and leave a permanent diff behind.
+// Returned entries must be put back into env once those readers have run.
+func withholdUserManagedEnv(env *helpermaps.Map[string, string], stateEnv types.Map) map[string]string {
+	withheld := map[string]string{}
+
+	if stateEnv.IsNull() || stateEnv.IsUnknown() {
+		return withheld
+	}
+
+	for key := range stateEnv.Elements() {
+		if value := env.PopPtr(key); value != nil {
+			withheld[key] = *value
+		}
+	}
+
+	return withheld
+}

--- a/pkg/resources/application/env_slot.go
+++ b/pkg/resources/application/env_slot.go
@@ -1,8 +1,14 @@
 package application
 
 import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	helpermaps "github.com/miton18/helper/maps"
+	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 )
 
 // withholdUserManagedEnv hides from the runtime, hook and integration readers
@@ -23,4 +29,84 @@ func withholdUserManagedEnv(env *helpermaps.Map[string, string], stateEnv types.
 	}
 
 	return withheld
+}
+
+// ValidateEnvSlots reports variables put in `environment` although a dedicated
+// attribute exists for them. Two cases, deliberately two distinct messages:
+// declared in both slots the plan cannot settle, declared in `environment` alone
+// it settles but gives up the attribute's typing and validation.
+func ValidateEnvSlots[P any, T interface {
+	*P
+	RuntimePlan
+}](ctx context.Context, plan T, diags *diag.Diagnostics) {
+	runtime := plan.GetRuntimePtr()
+	if runtime.Environment.IsNull() || runtime.Environment.IsUnknown() {
+		return
+	}
+
+	// the check is best effort: an undecodable plan is left to the CRUD operations to report
+	probe := diag.Diagnostics{}
+
+	// emptying `environment` leaves ToEnv with the attribute-derived variables only
+	configured := runtime.Environment
+	defer func() { runtime.Environment = configured }()
+
+	runtime.Environment = types.MapValueMust(types.StringType, map[string]attr.Value{})
+	derived := plan.ToEnv(ctx, &probe)
+	if probe.HasError() {
+		return
+	}
+
+	backed := attributeBackedKeys[P, T](ctx, configured, &probe)
+
+	for key := range configured.Elements() {
+		_, isDerived := derived[key]
+
+		switch {
+		case isDerived:
+			diags.AddAttributeWarning(
+				path.Root("environment").AtMapKey(key),
+				"Variable also managed by a dedicated attribute",
+				key+" is set in `environment` and by the attribute dedicated to it. "+
+					"The attribute wins when Terraform writes to Clever Cloud, `environment` wins on refresh, "+
+					"so the plan cannot settle. Prefer the dedicated attribute and remove the variable from `environment`.",
+			)
+		case backed[key]:
+			diags.AddAttributeWarning(
+				path.Root("environment").AtMapKey(key),
+				"Variable has a dedicated attribute",
+				key+" is set in `environment` while a dedicated attribute exists for it. "+
+					"Both reach Clever Cloud, but the attribute is typed and validated where `environment` "+
+					"is a plain string map. Prefer the dedicated attribute.",
+			)
+		}
+	}
+}
+
+// attributeBackedKeys returns the keys of `environment` that a dedicated attribute
+// would claim on refresh. FromEnv pops what it consumes, so whatever survives has no
+// attribute behind it. Values are irrelevant — every reader keys off presence — which
+// is what keeps the check working when the practitioner interpolates an unknown value.
+// FromEnv writes to its receiver, hence the scratch plan rather than the real one.
+func attributeBackedKeys[P any, T interface {
+	*P
+	RuntimePlan
+}](ctx context.Context, configured types.Map, diags *diag.Diagnostics) map[string]bool {
+	env := helpermaps.NewMap(map[string]string{})
+	for key := range configured.Elements() {
+		env.Set(key, "")
+	}
+
+	scratch := T(new(P))
+	scratch.FromEnv(ctx, env, diags)
+	attributes.FromEnvHooks(env, nil)
+
+	backed := map[string]bool{}
+	for key := range configured.Elements() {
+		if !env.Has(key) {
+			backed[key] = true
+		}
+	}
+
+	return backed
 }

--- a/pkg/resources/application/env_slot_test.go
+++ b/pkg/resources/application/env_slot_test.go
@@ -1,0 +1,83 @@
+package application
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	helpermaps "github.com/miton18/helper/maps"
+)
+
+func stateEnvMap(t *testing.T, entries map[string]string) types.Map {
+	t.Helper()
+
+	values := map[string]attr.Value{}
+	for key, value := range entries {
+		values[key] = types.StringValue(value)
+	}
+
+	return types.MapValueMust(types.StringType, values)
+}
+
+func TestWithholdUserManagedEnv(t *testing.T) {
+	cases := map[string]struct {
+		apiEnv       map[string]string
+		stateEnv     types.Map
+		wantWithheld map[string]string
+		wantLeft     map[string]string
+	}{
+		"no environment in state": {
+			apiEnv:       map[string]string{"CC_RUST_FEATURES": "a,b"},
+			stateEnv:     types.MapNull(types.StringType),
+			wantWithheld: map[string]string{},
+			wantLeft:     map[string]string{"CC_RUST_FEATURES": "a,b"},
+		},
+		"unknown environment in state": {
+			apiEnv:       map[string]string{"CC_RUST_FEATURES": "a,b"},
+			stateEnv:     types.MapUnknown(types.StringType),
+			wantWithheld: map[string]string{},
+			wantLeft:     map[string]string{"CC_RUST_FEATURES": "a,b"},
+		},
+		"derived var declared in environment": {
+			apiEnv:       map[string]string{"CC_RUST_FEATURES": "a,b", "MY_VAR": "42"},
+			stateEnv:     stateEnvMap(t, map[string]string{"CC_RUST_FEATURES": "a,b"}),
+			wantWithheld: map[string]string{"CC_RUST_FEATURES": "a,b"},
+			wantLeft:     map[string]string{"MY_VAR": "42"},
+		},
+		"derived var declared through its attribute": {
+			apiEnv:       map[string]string{"CC_RUST_FEATURES": "a,b"},
+			stateEnv:     stateEnvMap(t, map[string]string{"MY_VAR": "42"}),
+			wantWithheld: map[string]string{},
+			wantLeft:     map[string]string{"CC_RUST_FEATURES": "a,b"},
+		},
+		"declared var dropped on the API side": {
+			apiEnv:       map[string]string{"MY_VAR": "42"},
+			stateEnv:     stateEnvMap(t, map[string]string{"CC_PRE_BUILD_HOOK": "make"}),
+			wantWithheld: map[string]string{},
+			wantLeft:     map[string]string{"MY_VAR": "42"},
+		},
+		"value changed on the API side": {
+			apiEnv:       map[string]string{"CC_PRE_BUILD_HOOK": "make build"},
+			stateEnv:     stateEnvMap(t, map[string]string{"CC_PRE_BUILD_HOOK": "make"}),
+			wantWithheld: map[string]string{"CC_PRE_BUILD_HOOK": "make build"},
+			wantLeft:     map[string]string{},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			env := helpermaps.NewMap(tt.apiEnv)
+
+			withheld := withholdUserManagedEnv(env, tt.stateEnv)
+
+			if !maps.Equal(withheld, tt.wantWithheld) {
+				t.Errorf("withheld: expected %v, got %v", tt.wantWithheld, withheld)
+			}
+
+			if left := maps.Collect(env.All); !maps.Equal(left, tt.wantLeft) {
+				t.Errorf("remaining env: expected %v, got %v", tt.wantLeft, left)
+			}
+		})
+	}
+}

--- a/pkg/resources/application/env_slot_test.go
+++ b/pkg/resources/application/env_slot_test.go
@@ -1,12 +1,16 @@
 package application
 
 import (
+	"context"
 	"maps"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	helpermaps "github.com/miton18/helper/maps"
+	"go.clever-cloud.com/terraform-provider/pkg"
 )
 
 func stateEnvMap(t *testing.T, entries map[string]string) types.Map {
@@ -77,6 +81,122 @@ func TestWithholdUserManagedEnv(t *testing.T) {
 
 			if left := maps.Collect(env.All); !maps.Equal(left, tt.wantLeft) {
 				t.Errorf("remaining env: expected %v, got %v", tt.wantLeft, left)
+			}
+		})
+	}
+}
+
+// fakeRuntime stands in for a real runtime: CC_FAKE_FEATURE is its only
+// attribute-derived variable.
+type fakeRuntime struct {
+	Runtime
+	feature types.String
+}
+
+func (f fakeRuntime) ToEnv(ctx context.Context, diags *diag.Diagnostics) map[string]string {
+	env := map[string]string{}
+
+	custom := map[string]string{}
+	diags.Append(f.Environment.ElementsAs(ctx, &custom, false)...)
+	env = pkg.Merge(env, custom)
+
+	pkg.IfIsSetStr(f.feature, func(value string) { env["CC_FAKE_FEATURE"] = value })
+
+	return env
+}
+
+func (f fakeRuntime) ToDeployment(*http.BasicAuth) *Deployment { return nil }
+
+func (f *fakeRuntime) FromEnv(_ context.Context, env *helpermaps.Map[string, string], _ *diag.Diagnostics) {
+	f.feature = pkg.FromStrPtr(env.PopPtr("CC_FAKE_FEATURE"))
+}
+
+const (
+	duplicateSlotSummary = "Variable also managed by a dedicated attribute"
+	dedicatedSlotSummary = "Variable has a dedicated attribute"
+)
+
+func countBySummary(diags diag.Diagnostics, summary string) int {
+	count := 0
+	for _, d := range diags.Warnings() {
+		if d.Summary() == summary {
+			count++
+		}
+	}
+
+	return count
+}
+
+func TestValidateEnvSlots(t *testing.T) {
+	cases := map[string]struct {
+		environment   types.Map
+		feature       types.String
+		wantDuplicate int
+		wantDedicated int
+	}{
+		"declared in both slots": {
+			environment:   stateEnvMap(t, map[string]string{"CC_FAKE_FEATURE": "a", "MY_VAR": "42"}),
+			feature:       types.StringValue("a"),
+			wantDuplicate: 1,
+		},
+		"declared in environment only": {
+			environment:   stateEnvMap(t, map[string]string{"CC_FAKE_FEATURE": "a"}),
+			feature:       types.StringNull(),
+			wantDedicated: 1,
+		},
+		"declared through the attribute only": {
+			environment: stateEnvMap(t, map[string]string{"MY_VAR": "42"}),
+			feature:     types.StringValue("a"),
+		},
+		"variable with no dedicated attribute": {
+			environment: stateEnvMap(t, map[string]string{"MY_VAR": "42"}),
+			feature:     types.StringNull(),
+		},
+		"no environment": {
+			environment: types.MapNull(types.StringType),
+			feature:     types.StringValue("a"),
+		},
+		"unknown environment": {
+			environment: types.MapUnknown(types.StringType),
+			feature:     types.StringValue("a"),
+		},
+		// a value interpolated from a resource not created yet must not blind the check
+		"unknown value beside a duplicate": {
+			environment: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"CC_FAKE_FEATURE": types.StringValue("a"),
+				"INTERPOLATED":    types.StringUnknown(),
+			}),
+			feature:       types.StringValue("a"),
+			wantDuplicate: 1,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			plan := &fakeRuntime{feature: tt.feature}
+			plan.Environment = tt.environment
+
+			diags := diag.Diagnostics{}
+			ValidateEnvSlots(context.Background(), plan, &diags)
+
+			if diags.HasError() {
+				t.Fatalf("unexpected errors: %v", diags.Errors())
+			}
+
+			if got := countBySummary(diags, duplicateSlotSummary); got != tt.wantDuplicate {
+				t.Errorf("expected %d duplicate-slot warning(s), got %d: %v", tt.wantDuplicate, got, diags.Warnings())
+			}
+
+			if got := countBySummary(diags, dedicatedSlotSummary); got != tt.wantDedicated {
+				t.Errorf("expected %d dedicated-slot warning(s), got %d: %v", tt.wantDedicated, got, diags.Warnings())
+			}
+
+			if !plan.Environment.Equal(tt.environment) {
+				t.Errorf("environment was not restored: %v", plan.Environment)
+			}
+
+			if !plan.feature.Equal(tt.feature) {
+				t.Errorf("plan attribute was mutated: %v", plan.feature)
 			}
 		})
 	}

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -103,4 +103,5 @@ func (r *ResourceFrankenPHP) ModifyPlan(ctx context.Context, req resource.Modify
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "frankenphp", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceGo) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequ
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "go", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceJava) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, r.profile, plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceLinux) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "linux", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceNodeJS) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "node", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -101,4 +101,5 @@ func (r *ResourcePHP) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "php", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -104,4 +104,5 @@ func (r *ResourcePlay2) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "play2", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -101,4 +101,5 @@ func (r *ResourcePython) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "python", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -133,10 +133,17 @@ func Read[T RuntimePlan](ctx context.Context, resource RuntimeResource, state T)
 	// Read TCP redirection
 	runtime.Redirection = ReadTCPRedirection(ctx, resource.Client(), resource.Organization(), runtime.ID.ValueString(), runtime.Redirection, &diags)
 
+	// Variables the practitioner declares in `environment` keep that slot
+	withheld := withholdUserManagedEnv(env, runtime.Environment)
+
 	// Map environment variables to runtime-specific fields
 	state.FromEnv(ctx, env, &diags)
 
 	runtime.Hooks = attributes.FromEnvHooks(env, runtime.Hooks)
+
+	for key, value := range withheld {
+		env.Set(key, value)
+	}
 
 	if env.Size() > 0 {
 		nativeEnvMap := maps.Collect(env.All)

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceRuby) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "ruby", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -101,4 +101,5 @@ func (r *ResourceRust) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "rust", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/rust/rust_test.go
+++ b/pkg/resources/application/rust/rust_test.go
@@ -128,3 +128,104 @@ resource "clevercloud_rust" "test" {
 		},
 	})
 }
+
+const rustEnvSlotConfig = `
+resource "clevercloud_rust" "%[1]s" {
+  name               = "%[1]s"
+  region             = "par"
+  min_instance_count = 1
+  max_instance_count = 1
+  smallest_flavor    = "XS"
+  biggest_flavor     = "XS"
+
+  environment = {
+    APP_FOLDER        = "server"
+    CC_RUST_FEATURES  = "feature1,feature2"
+    CC_PRE_BUILD_HOOK = "echo pre-build"
+    MY_VAR            = "plain"
+  }
+}`
+
+const rustAttrSlotConfig = `
+resource "clevercloud_rust" "%[1]s" {
+  name               = "%[1]s"
+  region             = "par"
+  min_instance_count = 1
+  max_instance_count = 1
+  smallest_flavor    = "XS"
+  biggest_flavor     = "XS"
+
+  app_folder = "server"
+  features   = ["feature1", "feature2"]
+
+  environment = {
+    MY_VAR = "plain"
+  }
+
+  hooks {
+    pre_build = "echo pre-build"
+  }
+}`
+
+// TestAccRust_envSlotPreserved checks that a variable stays in the slot it was
+// declared in. Each config is followed by a refresh-only step expecting an empty
+// plan: that is where the bug showed, refresh moved attribute-backed variables out
+// of `environment` and the next plan reverted them for ever.
+func TestAccRust_envSlotPreserved(t *testing.T) {
+	ctx := t.Context()
+	rName := acctest.RandomWithPrefix("tf-test-rust-slot")
+	fullName := fmt.Sprintf("clevercloud_rust.%s", rName)
+	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION).String()
+
+	envSlotChecks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("features"), knownvalue.Null()),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("hooks"), knownvalue.Null()),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("app_folder"), knownvalue.Null()),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("environment"), knownvalue.MapExact(map[string]knownvalue.Check{
+			"APP_FOLDER":        knownvalue.StringExact("server"),
+			"CC_RUST_FEATURES":  knownvalue.StringExact("feature1,feature2"),
+			"CC_PRE_BUILD_HOOK": knownvalue.StringExact("echo pre-build"),
+			"MY_VAR":            knownvalue.StringExact("plain"),
+		})),
+	}
+
+	attrSlotChecks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("features"), knownvalue.SetExact([]knownvalue.Check{
+			knownvalue.StringExact("feature1"),
+			knownvalue.StringExact("feature2"),
+		})),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("hooks").AtMapKey("pre_build"), knownvalue.StringExact("echo pre-build")),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("app_folder"), knownvalue.StringExact("server")),
+		statecheck.ExpectKnownValue(fullName, tfjsonpath.New("environment"), knownvalue.MapExact(map[string]knownvalue.Check{
+			"MY_VAR": knownvalue.StringExact("plain"),
+		})),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tests.ProtoV6Provider,
+		PreCheck:                 tests.ExpectOrganisation(t),
+		CheckDestroy:             tests.CheckDestroy(ctx),
+		Steps: []resource.TestStep{{
+			Config:            providerBlock + fmt.Sprintf(rustEnvSlotConfig, rName),
+			ConfigStateChecks: envSlotChecks,
+		}, {
+			Config:             providerBlock + fmt.Sprintf(rustEnvSlotConfig, rName),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false, // the fix: refresh leaves every variable in `environment`
+		}, {
+			Config:            providerBlock + fmt.Sprintf(rustAttrSlotConfig, rName),
+			ConfigStateChecks: attrSlotChecks,
+		}, {
+			Config:             providerBlock + fmt.Sprintf(rustAttrSlotConfig, rName),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false, // default routing still applies when `environment` is empty
+		}, {
+			Config:            providerBlock + fmt.Sprintf(rustEnvSlotConfig, rName),
+			ConfigStateChecks: envSlotChecks,
+		}, {
+			Config:             providerBlock + fmt.Sprintf(rustEnvSlotConfig, rName),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false, // attribute slot back to `environment` converges too
+		}},
+	})
+}

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceScala) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "sbt", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/schema.go
+++ b/pkg/resources/application/schema.go
@@ -133,8 +133,8 @@ var runtimeCommon = map[string]schema.Attribute{
 	"environment": schema.MapAttribute{
 		Optional:            true,
 		Sensitive:           true,
-		Description:         "Environment variables injected into the application. Null values are not allowed - use a for expression to filter optional variables.",
-		MarkdownDescription: "Environment variables injected into the application.\n\n**Note:** Null values are not allowed. To conditionally include variables, use a for expression:\n```hcl\nenvironment = { for k, v in {\n  VAR1 = \"value\"\n  VAR2 = var.optional_var\n} : k => v if v != null }\n```",
+		Description:         "Environment variables injected into the application. Null values are not allowed - use a for expression to filter optional variables. Prefer the dedicated attribute (java_version, hooks.pre_build...) when one exists: setting the variable here works but gives up typing and validation, and setting it in both slots never reaches a stable plan.",
+		MarkdownDescription: "Environment variables injected into the application.\n\n**Note:** Null values are not allowed. To conditionally include variables, use a for expression:\n```hcl\nenvironment = { for k, v in {\n  VAR1 = \"value\"\n  VAR2 = var.optional_var\n} : k => v if v != null }\n```\n\n**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.",
 		ElementType:         types.StringType,
 		Validators:          []validator.Map{pkg.NoNullMapValuesValidator()},
 	},
@@ -264,8 +264,8 @@ var runtimeCommonV0 = map[string]schema.Attribute{
 	"environment": schema.MapAttribute{
 		Optional:            true,
 		Sensitive:           true,
-		Description:         "Environment variables injected into the application. Null values are not allowed - use a for expression to filter optional variables.",
-		MarkdownDescription: "Environment variables injected into the application.\n\n**Note:** Null values are not allowed. To conditionally include variables, use a for expression:\n```hcl\nenvironment = { for k, v in {\n  VAR1 = \"value\"\n  VAR2 = var.optional_var\n} : k => v if v != null }\n```",
+		Description:         "Environment variables injected into the application. Null values are not allowed - use a for expression to filter optional variables. Prefer the dedicated attribute (java_version, hooks.pre_build...) when one exists: setting the variable here works but gives up typing and validation, and setting it in both slots never reaches a stable plan.",
+		MarkdownDescription: "Environment variables injected into the application.\n\n**Note:** Null values are not allowed. To conditionally include variables, use a for expression:\n```hcl\nenvironment = { for k, v in {\n  VAR1 = \"value\"\n  VAR2 = var.optional_var\n} : k => v if v != null }\n```\n\n**Note:** Prefer the dedicated attribute (`java_version`, `hooks.pre_build`...) whenever one exists. Declaring the variable here works but gives up the attribute's typing and validation. Declaring it in **both** slots never reaches a stable plan: the attribute wins when Terraform writes to Clever Cloud, this map wins on refresh.",
 		ElementType:         types.StringType,
 		Validators:          []validator.Map{pkg.NoNullMapValuesValidator()},
 	},

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceStatic) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "static", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceStaticApache) ModifyPlan(ctx context.Context, req resource.Modi
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "static-apache", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -104,4 +104,5 @@ func (r *ResourceV) ModifyPlan(ctx context.Context, req resource.ModifyPlanReque
 	}
 
 	application.ValidateRuntimeFlavors(ctx, r, "v", plan.Runtime, &res.Diagnostics)
+	application.ValidateEnvSlots(ctx, &plan, &res.Diagnostics)
 }


### PR DESCRIPTION
## Problem

`Read` moves attribute-backed variables (`CC_RUST_FEATURES`, `CC_*_HOOK`, `CC_JAVA_VERSION`, integrations…) out of `environment` and into their dedicated attribute, whatever the config says.
A config declaring one of them as a plain env var therefore never reaches a stable plan: apply writes the config back, the next refresh flips it again.

Partially addresses #293: declaring a variable in one slot is fixed, declaring it in both is reported with a warning rather than fixed.

## Resolution

- `Read` withholds from the runtime, hook and integration readers every key the prior state holds in `environment`, and restores it afterwards — each variable keeps the slot the practitioner chose.
- Key-agnostic: no list of variables to maintain, so all runtimes, the `hooks` block and the `integrations` block are covered, including attributes added later.
- A variable declared in **both** slots still cannot settle — the attribute wins on write, `environment` on refresh. Reported as a plan-time warning pointing at the dedicated attribute, not an error, so existing configurations keep applying.
- Unit tests for both paths; checked against a live Rust app declaring two features and five hooks through each slot in turn.

## Before / after

Same config, same state, `plan` immediately after a successful `apply`:

```diff
# before
  ~ resource "clevercloud_rust" "env_slot" {
      - app_folder  = "server" -> null
      ~ environment = {
          + "APP_FOLDER"            = "server"
          + "CC_POST_BUILD_HOOK"    = "echo post-build"
          + "CC_PRE_BUILD_HOOK"     = "echo pre-build"
          + "CC_PRE_RUN_HOOK"       = "echo pre-run"
          + "CC_RUN_FAILED_HOOK"    = "echo run-failed"
          + "CC_RUN_SUCCEEDED_HOOK" = "echo run-succeeded"
          + "CC_RUST_FEATURES"      = "module_build_cache,module_product_pulsar"
            # (1 unchanged element hidden)
        }
      - features    = [
          - "module_build_cache",
          - "module_product_pulsar",
        ] -> null
      - hooks {
          - post_build  = "echo post-build" -> null
          - pre_build   = "echo pre-build" -> null
          - pre_run     = "echo pre-run" -> null
          - run_failed  = "echo run-failed" -> null
          - run_succeed = "echo run-succeeded" -> null
        }
    }

# after
  No changes. Your infrastructure matches the configuration.
```

Removing a hook is then reported in the slot it was declared in — as `environment` keys going away for an app using env vars, as block attributes going `null` for an app using `hooks {}`.
