### PR TITLE
feat(applications): reflect the deployed commit in deployment.commit

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,17 @@ description: |-
   Gérer les applications de mes organisations
   Gérer les add-ons de mes organisations
   
+  Applications: deployment and the commit attribute
+  The deployment block drives how Terraform deploys your application, and its commit attribute reflects the commit currently running on it.
+  | configuration | behaviour |
+  |---|---|
+  | no `deployment` block | you deploy outside of Terraform (CLI, console, CI...), the provider never reconciles anything deployment-related and never shows a diff |
+  | block without `commit` | the repository HEAD is deployed on create/update; `commit` is computed with the running hash, and a deployment done outside of Terraform silently updates it on the next refresh |
+  | `commit = "<hash>"` | the commit is pinned: a deployment done outside of Terraform shows up as a diff and the next apply re-deploys the pinned hash |
+  | `commit = "refs/heads/..."` | the reference is resolved and deployed; the value is kept as-is in the state |
+  | `commit = "github_hook"` | deployments are delegated to GitHub, the provider never pushes nor reconciles the running commit |
+  Known limitations
+  Import: terraform import does not populate the deployment block (the provider cannot tell whether you want to manage deployments with Terraform). Add the block to your configuration to start tracking the running commit — be aware that the first apply then triggers a deployment.Git references: when commit holds a reference (refs/heads/...), the running commit is not reported and deployments done outside of Terraform are not detected (a local reference cannot be compared to the running hash without cloning the repository).Switching from a reference to the computed commit: removing commit = "refs/heads/..." from the configuration keeps the reference in the state; re-create the resource (or set an explicit hash once) to switch to the computed behaviour.Repository HEAD moves, nothing else changes: terraform plan does not clone the repository, so a new commit on your branch does not show up as a diff by itself; the push happens on the next apply that carries a change.State freshness on update: when an update deploys a new HEAD while commit is not configured, the state reports the new hash after the next refresh (Terraform requires the applied value to match the planned one).
   Applications: private repository deployment
   To deploy from a private GitHub repository, you need to generate a Personal Access Token (PAT) that will be used for authentication.
   Creating a GitHub Personal Access Token
@@ -67,6 +78,26 @@ Gérer mes organisations
 Gérer les applications de mes organisations
 Gérer les add-ons de mes organisations
 ```
+
+## Applications: deployment and the commit attribute
+
+The `deployment` block drives how Terraform deploys your application, and its `commit` attribute reflects the commit currently running on it.
+
+| configuration | behaviour |
+|---|---|
+| no `deployment` block | you deploy outside of Terraform (CLI, console, CI...), the provider never reconciles anything deployment-related and never shows a diff |
+| block without `commit` | the repository HEAD is deployed on create/update; `commit` is computed with the running hash, and a deployment done outside of Terraform silently updates it on the next refresh |
+| `commit = "<hash>"` | the commit is pinned: a deployment done outside of Terraform shows up as a diff and the next apply re-deploys the pinned hash |
+| `commit = "refs/heads/..."` | the reference is resolved and deployed; the value is kept as-is in the state |
+| `commit = "github_hook"` | deployments are delegated to GitHub, the provider never pushes nor reconciles the running commit |
+
+### Known limitations
+
+- **Import**: `terraform import` does not populate the `deployment` block (the provider cannot tell whether you want to manage deployments with Terraform). Add the block to your configuration to start tracking the running commit — be aware that the first apply then triggers a deployment.
+- **Git references**: when `commit` holds a reference (`refs/heads/...`), the running commit is not reported and deployments done outside of Terraform are not detected (a local reference cannot be compared to the running hash without cloning the repository).
+- **Switching from a reference to the computed commit**: removing `commit = "refs/heads/..."` from the configuration keeps the reference in the state; re-create the resource (or set an explicit hash once) to switch to the computed behaviour.
+- **Repository HEAD moves, nothing else changes**: `terraform plan` does not clone the repository, so a new commit on your branch does not show up as a diff by itself; the push happens on the next apply that carries a change.
+- **State freshness on update**: when an update deploys a new HEAD while `commit` is not configured, the state reports the new hash after the next refresh (Terraform requires the applied value to match the planned one).
 
 ## Applications: private repository deployment
 

--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -90,7 +90,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -52,7 +52,7 @@ resource "clevercloud_docker" "docker_instance" {
 - `daemon_socket_mount` (Boolean) Set to true to access the host Docker socket from inside your container
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `dockerfile` (String) The name of the Dockerfile to build
 - `enable_ipv6` (Boolean, Deprecated)

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -129,7 +129,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -93,7 +93,7 @@ resource "clevercloud_dotnet" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -74,7 +74,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -41,7 +41,7 @@ FrankenPHP is a modern PHP application server, written in Go. It gives superpowe
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `dev_dependencies` (Boolean) Install development dependencies (Default: false)
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -129,7 +129,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -97,7 +97,7 @@ resource "clevercloud_go" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/haskell.md
+++ b/docs/resources/haskell.md
@@ -93,7 +93,7 @@ resource "clevercloud_haskell" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/haskell.md
+++ b/docs/resources/haskell.md
@@ -129,7 +129,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -97,7 +97,7 @@ resource "clevercloud_java_war" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -130,7 +130,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -97,7 +97,7 @@ resource "clevercloud_java_war" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -130,7 +130,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -142,7 +142,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -106,7 +106,7 @@ resource "clevercloud_linux" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `disable_mise` (Boolean) Disable Mise tool installation (Default: false).
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -97,7 +97,7 @@ resource "clevercloud_nodejs" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `dev_dependencies` (Boolean) Install development dependencies specified in package.json
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -134,7 +134,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -70,7 +70,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -34,7 +34,7 @@ See [PHP with Apache product specification](https://www.clever.cloud/developers/
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `dev_dependencies` (Boolean) Install development dependencies
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -129,7 +129,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -97,7 +97,7 @@ resource "clevercloud_play2" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -131,7 +131,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -97,7 +97,7 @@ resource "clevercloud_python" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -168,7 +168,7 @@ resource "clevercloud_ruby" "custom_ruby_app" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `enable_gzip_compression` (Boolean) Set to true to gzip-compress through Nginx
 - `enable_sidekiq` (Boolean) Enable Sidekiq background process

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -216,7 +216,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -97,7 +97,7 @@ resource "clevercloud_rust" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -130,7 +130,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -97,7 +97,7 @@ resource "clevercloud_scala" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -129,7 +129,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -132,7 +132,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -100,7 +100,7 @@ resource "clevercloud_static" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -165,7 +165,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -133,7 +133,7 @@ resource "clevercloud_static_apache" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.
 

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -94,7 +94,7 @@ resource "clevercloud_v" "myapp" {
 - `build_flavor` (String) Use dedicated instance with given flavor for build phase
 - `dependencies` (Set of String) A list of application or add-ons required to run this application.
 Can be either app_xxx or postgres_yyy ID format
-- `deployment` (Block, Optional) (see [below for nested schema](#nestedblock--deployment))
+- `deployment` (Block, Optional) Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Application description
 - `development_build` (Boolean) Set to true to compile without the `-prod` flag.
 - `environment` (Map of String, Sensitive) Environment variables injected into the application.

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -127,7 +127,7 @@ environment = { for k, v in {
 Optional:
 
 - `authentication_basic` (String, Sensitive) user ans password ':' separated, (PersonalAccessToken in Github case)
-- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository
+- `commit` (String) Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application
 - `repository` (String) The repository URL to deploy, can be 'https://...', 'file://...'
 
 

--- a/pkg/attributes/blocks.go
+++ b/pkg/attributes/blocks.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -249,8 +251,14 @@ var blocks = map[string]schema.Block{
 			},
 			"commit": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "The git reference you want to deploy",
-				MarkdownDescription: "Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository",
+				MarkdownDescription: "Support multiple syntax like `refs/heads/[BRANCH]`, `github_hook` or `[COMMIT]`, when using the special value `github_hook`, we will link the application to the Github repository. When omitted, the repository HEAD is deployed and this attribute reflects the commit currently running on the application",
+				PlanModifiers: []planmodifier.String{
+					// when not configured, keep the deployed commit from the
+					// state instead of planning "known after apply" every time
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					pkg.NewValidator(
 						"if reference (not commit hash) is provided test it's syntax",

--- a/pkg/attributes/blocks.go
+++ b/pkg/attributes/blocks.go
@@ -243,6 +243,7 @@ var IntegrationsAttribute = schema.SingleNestedAttribute{
 
 var blocks = map[string]schema.Block{
 	"deployment": schema.SingleNestedBlock{
+		MarkdownDescription: "Git deployment configuration, see the [deployment guide](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs#applications-deployment-and-the-commit-attribute) for the full behaviour",
 		Attributes: map[string]schema.Attribute{
 			"repository": schema.StringAttribute{
 				Optional:            true, // If "deployment" attribute is defined, then repository is required

--- a/pkg/helper/state.go
+++ b/pkg/helper/state.go
@@ -19,6 +19,10 @@ func StateFrom[T any](ctx context.Context, s tfsdk.State, diags *diag.Diagnostic
 	return *From[T](ctx, s, diags)
 }
 
+func ConfigFrom[T any](ctx context.Context, c tfsdk.Config, diags *diag.Diagnostics) T {
+	return *From[T](ctx, c, diags)
+}
+
 func From[T any](ctx context.Context, src TFStruct, diags *diag.Diagnostics) *T {
 	if src == nil {
 		return nil

--- a/pkg/provider/impl/provider.md
+++ b/pkg/provider/impl/provider.md
@@ -21,6 +21,26 @@ Gérer les applications de mes organisations
 Gérer les add-ons de mes organisations
 ```
 
+## Applications: deployment and the commit attribute
+
+The `deployment` block drives how Terraform deploys your application, and its `commit` attribute reflects the commit currently running on it.
+
+| configuration | behaviour |
+|---|---|
+| no `deployment` block | you deploy outside of Terraform (CLI, console, CI...), the provider never reconciles anything deployment-related and never shows a diff |
+| block without `commit` | the repository HEAD is deployed on create/update; `commit` is computed with the running hash, and a deployment done outside of Terraform silently updates it on the next refresh |
+| `commit = "<hash>"` | the commit is pinned: a deployment done outside of Terraform shows up as a diff and the next apply re-deploys the pinned hash |
+| `commit = "refs/heads/..."` | the reference is resolved and deployed; the value is kept as-is in the state |
+| `commit = "github_hook"` | deployments are delegated to GitHub, the provider never pushes nor reconciles the running commit |
+
+### Known limitations
+
+- **Import**: `terraform import` does not populate the `deployment` block (the provider cannot tell whether you want to manage deployments with Terraform). Add the block to your configuration to start tracking the running commit — be aware that the first apply then triggers a deployment.
+- **Git references**: when `commit` holds a reference (`refs/heads/...`), the running commit is not reported and deployments done outside of Terraform are not detected (a local reference cannot be compared to the running hash without cloning the repository).
+- **Switching from a reference to the computed commit**: removing `commit = "refs/heads/..."` from the configuration keeps the reference in the state; re-create the resource (or set an explicit hash once) to switch to the computed behaviour.
+- **Repository HEAD moves, nothing else changes**: `terraform plan` does not clone the repository, so a new commit on your branch does not show up as a diff by itself; the push happens on the next apply that carries a change.
+- **State freshness on update**: when an update deploys a new HEAD while `commit` is not configured, the state reports the new hash after the next refresh (Terraform requires the applied value to match the planned one).
+
 ## Applications: private repository deployment
 
 To deploy from a private GitHub repository, you need to generate a Personal Access Token (PAT) that will be used for authentication.

--- a/pkg/resources/application/create.go
+++ b/pkg/resources/application/create.go
@@ -28,6 +28,9 @@ type CreateReq struct {
 // CreateRes represents the response from creating an application
 type CreateRes struct {
 	Application tmp.AppResponse
+	// TargetCommit is the commit resolved by the git deployment on Update
+	// (pushed or already running), empty when no deployment is configured
+	TargetCommit string
 }
 
 // Deployment contains git deployment configuration

--- a/pkg/resources/application/deployment.go
+++ b/pkg/resources/application/deployment.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg/attributes"
+)
+
+// Deploy pushes the configured repository to the application Clever remote on
+// Create, then resolves the computed `deployment.commit` attribute with the
+// commit actually deployed (null when no push happened).
+func Deploy(ctx context.Context, resource RuntimeResource, plan RuntimePlan, diags *diag.Diagnostics) {
+	runtime := plan.GetRuntimePtr()
+
+	commit, _ := GitDeploy(ctx, plan.ToDeployment(resource.GitAuth()), runtime.DeployURL.ValueString(), "", diags)
+	resolveUnknownCommit(runtime.Deployment, commit)
+}
+
+// resolveUnknownCommit fills the computed `deployment.commit` attribute after
+// a Create/Update: when the commit is not set in the configuration, its
+// planned value is unknown and must be resolved to a known value before
+// saving the state. Values coming from the configuration or the previous
+// state are already known and kept as-is.
+func resolveUnknownCommit(d *attributes.Deployment, commit string) {
+	if d == nil || !d.Commit.IsUnknown() {
+		return
+	}
+
+	if commit == "" {
+		d.Commit = types.StringNull()
+	} else {
+		d.Commit = types.StringValue(commit)
+	}
+}
+
+// syncDeploymentCommit reflects in the state the commit currently running on
+// the application (CommitID from the API):
+//   - no deployment block: the user does not manage deployments with
+//     Terraform, nothing is reconciled so no diff shows up
+//   - commit holding a git reference (refs/heads/...) or `github_hook`: kept
+//     as-is, overwriting it with the running hash would fight the
+//     configuration and create a permanent diff
+//   - otherwise (null or commit hash): the running commit is reported, so a
+//     deployment done outside Terraform is visible in the state and a pinned
+//     commit detects drift
+func syncDeploymentCommit(d *attributes.Deployment, runningCommit string) {
+	if d == nil || runningCommit == "" {
+		return
+	}
+
+	if !d.Commit.IsNull() && !IsSHA1(d.Commit.ValueString()) {
+		return
+	}
+
+	d.Commit = types.StringValue(runningCommit)
+}

--- a/pkg/resources/application/deployment_test.go
+++ b/pkg/resources/application/deployment_test.go
@@ -1,0 +1,89 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.clever-cloud.com/terraform-provider/pkg/attributes"
+)
+
+const (
+	testSHA        = "a397296e135b24e682a011e31f8e15f2fa8a5a0e"
+	testAnotherSHA = "b5f4de2a1c1b24e682a011e31f8e15f2fa8a5a0e"
+)
+
+func TestResolveUnknownCommit(t *testing.T) {
+	t.Run("nil deployment is a no-op", func(t *testing.T) {
+		resolveUnknownCommit(nil, testSHA)
+	})
+
+	t.Run("unknown commit resolved to the deployed one", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringUnknown()}
+		resolveUnknownCommit(d, testSHA)
+		if d.Commit.ValueString() != testSHA {
+			t.Fatalf("expected %s, got %s", testSHA, d.Commit)
+		}
+	})
+
+	t.Run("unknown commit resolved to null when nothing was deployed", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringUnknown()}
+		resolveUnknownCommit(d, "")
+		if !d.Commit.IsNull() {
+			t.Fatalf("expected null, got %s", d.Commit)
+		}
+	})
+
+	t.Run("known commit is kept", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringValue("refs/heads/main")}
+		resolveUnknownCommit(d, testSHA)
+		if d.Commit.ValueString() != "refs/heads/main" {
+			t.Fatalf("expected refs/heads/main, got %s", d.Commit)
+		}
+	})
+}
+
+func TestSyncDeploymentCommit(t *testing.T) {
+	t.Run("nil deployment is a no-op", func(t *testing.T) {
+		syncDeploymentCommit(nil, testSHA)
+	})
+
+	t.Run("null commit takes the running one", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringNull()}
+		syncDeploymentCommit(d, testSHA)
+		if d.Commit.ValueString() != testSHA {
+			t.Fatalf("expected %s, got %s", testSHA, d.Commit)
+		}
+	})
+
+	t.Run("hash commit takes the running one (drift)", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringValue(testSHA)}
+		syncDeploymentCommit(d, testAnotherSHA)
+		if d.Commit.ValueString() != testAnotherSHA {
+			t.Fatalf("expected %s, got %s", testAnotherSHA, d.Commit)
+		}
+	})
+
+	t.Run("git reference is kept", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringValue("refs/heads/main")}
+		syncDeploymentCommit(d, testSHA)
+		if d.Commit.ValueString() != "refs/heads/main" {
+			t.Fatalf("expected refs/heads/main, got %s", d.Commit)
+		}
+	})
+
+	t.Run("github_hook is kept", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringValue(attributes.GITHUB_COMMIT_PREFIX)}
+		syncDeploymentCommit(d, testSHA)
+		if d.Commit.ValueString() != attributes.GITHUB_COMMIT_PREFIX {
+			t.Fatalf("expected %s, got %s", attributes.GITHUB_COMMIT_PREFIX, d.Commit)
+		}
+	})
+
+	t.Run("empty running commit keeps the state", func(t *testing.T) {
+		d := &attributes.Deployment{Commit: types.StringNull()}
+		syncDeploymentCommit(d, "")
+		if !d.Commit.IsNull() {
+			t.Fatalf("expected null, got %s", d.Commit)
+		}
+	})
+}

--- a/pkg/resources/application/docker/crud.go
+++ b/pkg/resources/application/docker/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceDocker) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -73,7 +73,12 @@ func (r *ResourceDocker) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Docker](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/docker/schema.go
+++ b/pkg/resources/application/docker/schema.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -220,26 +218,4 @@ func (p *Docker) FromEnv(ctx context.Context, env *maps.Map[string, string], dia
 	p.DaemonSocketMount = pkg.FromBoolPtr(env.PopPtr("CC_MOUNT_DOCKER_SOCKET"))
 
 	p.Integrations = attributes.FromEnvIntegrations(ctx, env, p.Integrations, diags)
-}
-
-func (p *Docker) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if p.Deployment == nil || p.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    p.Deployment.Repository.ValueString(),
-		Commit:        p.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !p.Deployment.BasicAuthentication.IsNull() && !p.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := p.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/dotnet/crud.go
+++ b/pkg/resources/application/dotnet/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceDotnet) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceDotnet) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Dotnet](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/dotnet/schema.go
+++ b/pkg/resources/application/dotnet/schema.go
@@ -3,12 +3,10 @@ package dotnet
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -82,26 +80,4 @@ func (dotnetapp *Dotnet) FromEnv(ctx context.Context, env *maps.Map[string, stri
 	dotnetapp.DotnetVersion = pkg.FromStrPtr(env.PopPtr("CC_DOTNET_VERSION"))
 
 	dotnetapp.Integrations = attributes.FromEnvIntegrations(ctx, env, dotnetapp.Integrations, diags)
-}
-
-func (dotnetapp Dotnet) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if dotnetapp.Deployment == nil || dotnetapp.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    dotnetapp.Deployment.Repository.ValueString(),
-		Commit:        dotnetapp.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !dotnetapp.Deployment.BasicAuthentication.IsNull() && !dotnetapp.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := dotnetapp.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/frankenphp/crud.go
+++ b/pkg/resources/application/frankenphp/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceFrankenPHP) Create(ctx context.Context, req resource.CreateRequ
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -75,7 +75,12 @@ func (r *ResourceFrankenPHP) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[FrankenPHP](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/frankenphp/schema.go
+++ b/pkg/resources/application/frankenphp/schema.go
@@ -3,12 +3,10 @@ package frankenphp
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -69,26 +67,4 @@ func (fp *FrankenPHP) FromEnv(ctx context.Context, env *maps.Map[string, string]
 	pkg.SetBoolIf(&fp.DevDependencies, env.PopPtr("CC_PHP_DEV_DEPENDENCIES"), "install")
 
 	fp.Integrations = attributes.FromEnvIntegrations(ctx, env, fp.Integrations, diags)
-}
-
-func (fp *FrankenPHP) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if fp.Deployment == nil || fp.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    fp.Deployment.Repository.ValueString(),
-		Commit:        fp.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !fp.Deployment.BasicAuthentication.IsNull() && !fp.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := fp.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/git.go
+++ b/pkg/resources/application/git.go
@@ -24,23 +24,26 @@ import (
 // deployedCommit is the commit currently deployed on the application (CommitID
 // from the API, empty when unknown or never deployed): when the resolved
 // target commit already matches it, the push is skipped.
-// It returns true only when a push actually triggered a deployment, so the
-// caller can decide whether an explicit restart is still needed (e.g. when
-// only environment variables changed).
-func GitDeploy(ctx context.Context, d *Deployment, cleverRemote, deployedCommit string, diags *diag.Diagnostics) bool {
+// It returns the resolved target commit (empty when no deployment is
+// configured, the repository is handled by Github or the resolution failed)
+// and true only when a push actually triggered a deployment, so the caller
+// can decide whether an explicit restart is still needed (e.g. when only
+// environment variables changed).
+func GitDeploy(ctx context.Context, d *Deployment, cleverRemote, deployedCommit string, diags *diag.Diagnostics) (string, bool) {
 	var errs diag.Diagnostics
+	var commit string
 	var deployed bool
 
 	if d == nil {
-		return false
+		return "", false
 	}
 	if d.Commit != nil && strings.HasPrefix(*d.Commit, attributes.GITHUB_COMMIT_PREFIX) {
 		tflog.Warn(ctx, "repository deployment is handled by Github, skipping deployment")
-		return false
+		return "", false
 	}
 
 	for range 5 {
-		deployed, errs = gitDeploy(ctx, *d, cleverRemote, deployedCommit)
+		commit, deployed, errs = gitDeploy(ctx, *d, cleverRemote, deployedCommit)
 		if !errs.HasError() {
 			break
 		}
@@ -50,27 +53,27 @@ func GitDeploy(ctx context.Context, d *Deployment, cleverRemote, deployedCommit 
 
 	// only add last error
 	diags.Append(errs...)
-	return deployed
+	return commit, deployed
 }
 
-func gitDeploy(ctx context.Context, d Deployment, cleverRemote, deployedCommit string) (bool, diag.Diagnostics) {
+func gitDeploy(ctx context.Context, d Deployment, cleverRemote, deployedCommit string) (string, bool, diag.Diagnostics) {
 	cleverRemote = strings.Replace(cleverRemote, "git+ssh", "https", 1) // switch protocol
 
 	repo, diags := OpenOrClone(ctx, d.Repository, WithCommit(d.Commit), WithBasicAuth(d.Username, d.Password))
 	if diags.HasError() {
-		return false, diags
+		return "", false, diags
 	}
 
 	targetCommit, diags := resolveTargetCommit(repo, d.Commit)
 	if diags.HasError() {
-		return false, diags
+		return "", false, diags
 	}
 
 	if deployedCommit != "" && targetCommit == deployedCommit {
 		tflog.Info(ctx, "deployed commit is already the expected one, skipping git push", map[string]any{
 			"commit": targetCommit,
 		})
-		return false, diags
+		return targetCommit, false, diags
 	}
 
 	remoteOpts := &config.RemoteConfig{
@@ -85,13 +88,13 @@ func gitDeploy(ctx context.Context, d Deployment, cleverRemote, deployedCommit s
 	remote, err := repo.CreateRemote(remoteOpts)
 	if err != nil {
 		diags.AddError("failed to add clever remote", err.Error())
-		return false, diags
+		return "", false, diags
 	}
 
 	refSpec := config.RefSpec(fmt.Sprintf("%s:%s", targetCommit, plumbing.Master))
 	if err := refSpec.Validate(); err != nil {
 		diags.AddError("failed to build ref spec to push", err.Error())
-		return false, diags
+		return "", false, diags
 	}
 
 	pushOptions := &git.PushOptions{
@@ -110,14 +113,14 @@ func gitDeploy(ctx context.Context, d Deployment, cleverRemote, deployedCommit s
 	if err != nil {
 		if err == git.NoErrAlreadyUpToDate {
 			diags.AddWarning("Git push rejected", "repository is already up-to-date")
-			return false, diags
+			return targetCommit, false, diags
 		}
 
 		diags.AddError("failed to push to clever remote", err.Error())
-		return false, diags
+		return "", false, diags
 	}
 
-	return true, diags
+	return targetCommit, true, diags
 }
 
 // resolveTargetCommit resolves the commit hash to deploy: the explicit

--- a/pkg/resources/application/golang/crud.go
+++ b/pkg/resources/application/golang/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceGo) Create(ctx context.Context, req resource.CreateRequest, res
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceGo) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Go](ctx, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/golang/schema.go
+++ b/pkg/resources/application/golang/schema.go
@@ -3,12 +3,10 @@ package golang
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -68,26 +66,4 @@ func (g *Go) FromEnv(ctx context.Context, env *maps.Map[string, string], diags *
 	g.AppFolder = pkg.FromStrPtr(env.PopPtr("APP_FOLDER"))
 
 	g.Integrations = attributes.FromEnvIntegrations(ctx, env, g.Integrations, diags)
-}
-
-func (g Go) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if g.Deployment == nil || g.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    g.Deployment.Repository.ValueString(),
-		Commit:        g.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !g.Deployment.BasicAuthentication.IsNull() && !g.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := g.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/haskell/crud.go
+++ b/pkg/resources/application/haskell/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceHaskell) Create(ctx context.Context, req resource.CreateRequest
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceHaskell) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Haskell](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/haskell/schema.go
+++ b/pkg/resources/application/haskell/schema.go
@@ -3,12 +3,10 @@ package haskell
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,26 +82,4 @@ func (haskellapp *Haskell) FromEnv(ctx context.Context, env *maps.Map[string, st
 	haskellapp.StackInstallDependenciesCommand = pkg.FromStrPtr(env.PopPtr("CC_HASKELL_STACK_INSTALL_DEPENDENCIES_COMMAND"))
 
 	haskellapp.Integrations = attributes.FromEnvIntegrations(ctx, env, haskellapp.Integrations, diags)
-}
-
-func (haskellapp Haskell) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if haskellapp.Deployment == nil || haskellapp.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    haskellapp.Deployment.Repository.ValueString(),
-		Commit:        haskellapp.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !haskellapp.Deployment.BasicAuthentication.IsNull() && !haskellapp.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := haskellapp.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/java/crud.go
+++ b/pkg/resources/application/java/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceJava) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceJava) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Java](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/java/schema.go
+++ b/pkg/resources/application/java/schema.go
@@ -3,14 +3,12 @@ package java
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
 	"maps"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,26 +82,4 @@ func (plan *Java) FromEnv(ctx context.Context, env *helperMaps.Map[string, strin
 	plan.JavaVersion = pkg.FromStrPtr(env.PopPtr("CC_JAVA_VERSION"))
 
 	plan.Integrations = attributes.FromEnvIntegrations(ctx, env, plan.Integrations, diags)
-}
-
-func (plan *Java) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if plan.Deployment == nil || plan.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    plan.Deployment.Repository.ValueString(),
-		Commit:        plan.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !plan.Deployment.BasicAuthentication.IsNull() && !plan.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := plan.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/linux/crud.go
+++ b/pkg/resources/application/linux/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceLinux) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceLinux) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Linux](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/linux/schema.go
+++ b/pkg/resources/application/linux/schema.go
@@ -3,12 +3,10 @@ package linux
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -100,26 +98,4 @@ func (l *Linux) FromEnv(ctx context.Context, env *maps.Map[string, string], diag
 	pkg.SetBoolIf(&l.DisableMise, env.PopPtr("CC_DISABLE_MISE"), "true")
 
 	l.Integrations = attributes.FromEnvIntegrations(ctx, env, l.Integrations, diags)
-}
-
-func (l *Linux) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if l.Deployment == nil || l.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    l.Deployment.Repository.ValueString(),
-		Commit:        l.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !l.Deployment.BasicAuthentication.IsNull() && !l.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema validation step
-		userPass := l.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/nodejs/crud.go
+++ b/pkg/resources/application/nodejs/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceNodeJS) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceNodeJS) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[NodeJS](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/nodejs/schema.go
+++ b/pkg/resources/application/nodejs/schema.go
@@ -3,12 +3,10 @@ package nodejs
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -143,26 +141,4 @@ func (node *NodeJS) FromEnv(ctx context.Context, env *maps.Map[string, string], 
 	node.RegistryToken = pkg.FromStrPtr(env.PopPtr("NPM_TOKEN"))
 
 	node.Integrations = attributes.FromEnvIntegrations(ctx, env, node.Integrations, diags)
-}
-
-func (node NodeJS) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if node.Deployment == nil || node.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    node.Deployment.Repository.ValueString(),
-		Commit:        node.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !node.Deployment.BasicAuthentication.IsNull() && !node.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := node.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/php/crud.go
+++ b/pkg/resources/application/php/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePHP) Create(ctx context.Context, req resource.CreateRequest, re
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -73,7 +73,12 @@ func (r *ResourcePHP) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[PHP](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/php/schema.go
+++ b/pkg/resources/application/php/schema.go
@@ -3,12 +3,10 @@ package php
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -131,26 +129,4 @@ func (p *PHP) FromEnv(ctx context.Context, env *maps.Map[string, string], diags 
 	pkg.SetBoolIf(&p.RedisSessions, env.PopPtr("SESSION_TYPE"), "redis")
 
 	p.Integrations = attributes.FromEnvIntegrations(ctx, env, p.Integrations, diags)
-}
-
-func (p *PHP) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if p.Deployment == nil || p.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    p.Deployment.Repository.ValueString(),
-		Commit:        p.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !p.Deployment.BasicAuthentication.IsNull() && !p.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := p.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/play2/crud.go
+++ b/pkg/resources/application/play2/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePlay2) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourcePlay2) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Play2](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/play2/schema.go
+++ b/pkg/resources/application/play2/schema.go
@@ -3,14 +3,12 @@ package play2
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
 	"maps"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -68,26 +66,4 @@ func (plan *Play2) ToEnv(ctx context.Context, diags *diag.Diagnostics) map[strin
 func (play2 *Play2) FromEnv(ctx context.Context, env *helperMaps.Map[string, string], diags *diag.Diagnostics) {
 	play2.AppFolder = pkg.FromStrPtr(env.PopPtr("APP_FOLDER"))
 	play2.Integrations = attributes.FromEnvIntegrations(ctx, env, play2.Integrations, diags)
-}
-
-func (play2 *Play2) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if play2.Deployment == nil || play2.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    play2.Deployment.Repository.ValueString(),
-		Commit:        play2.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !play2.Deployment.BasicAuthentication.IsNull() && !play2.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := play2.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/python/crud.go
+++ b/pkg/resources/application/python/crud.go
@@ -33,7 +33,7 @@ func (r *ResourcePython) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -73,7 +73,12 @@ func (r *ResourcePython) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Python](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/python/schema.go
+++ b/pkg/resources/application/python/schema.go
@@ -3,12 +3,10 @@ package python
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -99,26 +97,4 @@ func (py *Python) FromEnv(ctx context.Context, env *maps.Map[string, string], di
 	py.PipRequirements = pkg.FromStrPtr(env.PopPtr("CC_PIP_REQUIREMENTS_FILE"))
 
 	py.Integrations = attributes.FromEnvIntegrations(ctx, env, py.Integrations, diags)
-}
-
-func (py Python) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if py.Deployment == nil || py.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    py.Deployment.Repository.ValueString(),
-		Commit:        py.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !py.Deployment.BasicAuthentication.IsNull() && !py.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := py.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/read.go
+++ b/pkg/resources/application/read.go
@@ -154,5 +154,9 @@ func Read[T RuntimePlan](ctx context.Context, resource RuntimeResource, state T)
 	// Map API response to state
 	runtime.SetFromResponse(readRes, ctx, &diags)
 
+	// Reflect the commit currently running on the application, only when the
+	// user manages deployment through Terraform (deployment block present)
+	syncDeploymentCommit(runtime.Deployment, readRes.App.CommitID)
+
 	return false, diags
 }

--- a/pkg/resources/application/ruby/crud.go
+++ b/pkg/resources/application/ruby/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceRuby) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceRuby) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Ruby](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/ruby/schema.go
+++ b/pkg/resources/application/ruby/schema.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	_ "embed"
 	"strconv"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -306,26 +304,4 @@ func (ruby *Ruby) FromEnv(ctx context.Context, env *maps.Map[string, string], di
 	ruby.StaticWebroot = pkg.FromStrPtr(env.PopPtr("STATIC_WEBROOT"))
 
 	ruby.Integrations = attributes.FromEnvIntegrations(ctx, env, ruby.Integrations, diags)
-}
-
-func (ruby Ruby) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if ruby.Deployment == nil || ruby.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    ruby.Deployment.Repository.ValueString(),
-		Commit:        ruby.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !ruby.Deployment.BasicAuthentication.IsNull() && !ruby.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := ruby.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/runtime.go
+++ b/pkg/resources/application/runtime.go
@@ -3,7 +3,9 @@ package application
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.clever-cloud.com/terraform-provider/pkg"
@@ -123,4 +125,32 @@ func (r Runtime) VHostsAsStrings(ctx context.Context, diags *diag.Diagnostics) [
 // GetRuntimePtr returns a pointer to the Runtime struct for modification
 func (r *Runtime) GetRuntimePtr() *Runtime {
 	return r
+}
+
+// ToDeployment builds the git deployment configuration from the deployment block
+func (r *Runtime) ToDeployment(gitAuth *http.BasicAuth) *Deployment {
+	if r.Deployment == nil || r.Deployment.Repository.IsNull() {
+		return nil
+	}
+
+	d := &Deployment{
+		Repository:    r.Deployment.Repository.ValueString(),
+		CleverGitAuth: gitAuth,
+	}
+
+	// commit is Optional+Computed: an unknown value (resolved by the provider
+	// after the push) means no explicit target, the repository HEAD is deployed
+	if !r.Deployment.Commit.IsNull() && !r.Deployment.Commit.IsUnknown() {
+		d.Commit = r.Deployment.Commit.ValueStringPointer()
+	}
+
+	if !r.Deployment.BasicAuthentication.IsNull() && !r.Deployment.BasicAuthentication.IsUnknown() {
+		// Expect validation to be done in the schema validation step
+		userPass := r.Deployment.BasicAuthentication.ValueString()
+		splits := strings.SplitN(userPass, ":", 2)
+		d.Username = &splits[0]
+		d.Password = &splits[1]
+	}
+
+	return d
 }

--- a/pkg/resources/application/rust/crud.go
+++ b/pkg/resources/application/rust/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceRust) Create(ctx context.Context, req resource.CreateRequest, r
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -73,7 +73,12 @@ func (r *ResourceRust) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Rust](ctx, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/pkg/resources/application/rust/schema.go
+++ b/pkg/resources/application/rust/schema.go
@@ -8,7 +8,6 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -80,26 +79,4 @@ func (r *Rust) FromEnv(ctx context.Context, env *maps.Map[string, string], diags
 	r.Features = pkg.FromSetSplit(env.PopPtr(CC_RUST_FEATURES), ",", diags)
 
 	r.Integrations = attributes.FromEnvIntegrations(ctx, env, r.Integrations, diags)
-}
-
-func (r Rust) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if r.Deployment == nil || r.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    r.Deployment.Repository.ValueString(),
-		Commit:        r.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !r.Deployment.BasicAuthentication.IsNull() && !r.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := r.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/scala/crud.go
+++ b/pkg/resources/application/scala/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceScala) Create(ctx context.Context, req resource.CreateRequest, 
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceScala) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Scala](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/scala/schema.go
+++ b/pkg/resources/application/scala/schema.go
@@ -3,14 +3,12 @@ package scala
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
 	"maps"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -71,25 +69,4 @@ func (scala *Scala) FromEnv(ctx context.Context, env *helperMaps.Map[string, str
 	scala.AppFolder = pkg.FromStrPtr(env.PopPtr("APP_FOLDER"))
 
 	scala.Integrations = attributes.FromEnvIntegrations(ctx, env, scala.Integrations, diags)
-}
-
-func (java *Scala) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if java.Deployment == nil || java.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    java.Deployment.Repository.ValueString(),
-		Commit:        java.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-	if !java.Deployment.BasicAuthentication.IsNull() && !java.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := java.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/static/crud.go
+++ b/pkg/resources/application/static/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceStatic) Create(ctx context.Context, req resource.CreateRequest,
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceStatic) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[Static](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/static/schema.go
+++ b/pkg/resources/application/static/schema.go
@@ -3,12 +3,10 @@ package static
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -71,26 +69,4 @@ func (s *Static) FromEnv(ctx context.Context, env *maps.Map[string, string], dia
 	s.AppFolder = pkg.FromStrPtr(env.PopPtr("APP_FOLDER"))
 
 	s.Integrations = attributes.FromEnvIntegrations(ctx, env, s.Integrations, diags)
-}
-
-func (s *Static) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if s.Deployment == nil || s.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    s.Deployment.Repository.ValueString(),
-		Commit:        s.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !s.Deployment.BasicAuthentication.IsNull() && !s.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := s.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/staticapache/crud.go
+++ b/pkg/resources/application/staticapache/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceStaticApache) Create(ctx context.Context, req resource.CreateRe
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceStaticApache) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[StaticApache](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/staticapache/schema.go
+++ b/pkg/resources/application/staticapache/schema.go
@@ -3,12 +3,10 @@ package staticapache
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -71,26 +69,4 @@ func (s *StaticApache) FromEnv(ctx context.Context, env *maps.Map[string, string
 	s.AppFolder = pkg.FromStrPtr(env.PopPtr("APP_FOLDER"))
 
 	s.Integrations = attributes.FromEnvIntegrations(ctx, env, s.Integrations, diags)
-}
-
-func (s *StaticApache) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if s.Deployment == nil || s.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    s.Deployment.Repository.ValueString(),
-		Commit:        s.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !s.Deployment.BasicAuthentication.IsNull() && !s.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := s.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/application/update.go
+++ b/pkg/resources/application/update.go
@@ -64,7 +64,7 @@ func UpdateApp(ctx context.Context, req UpdateReq) (*CreateRes, diag.Diagnostics
 	// happens when they differ
 	gitDeployed := false
 	if req.Deployment != nil {
-		gitDeployed = GitDeploy(ctx, req.Deployment, res.Application.DeployURL, res.Application.CommitID, &diags)
+		res.TargetCommit, gitDeployed = GitDeploy(ctx, req.Deployment, res.Application.DeployURL, res.Application.CommitID, &diags)
 		if diags.HasError() {
 			return res, diags
 		}
@@ -86,8 +86,13 @@ func UpdateApp(ctx context.Context, req UpdateReq) (*CreateRes, diag.Diagnostics
 	return res, diags
 }
 
-// Update centralizes the common Update logic for all application runtimes
-func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, state T) diag.Diagnostics {
+// Update centralizes the common Update logic for all application runtimes.
+// config is needed on top of plan for the deployment block: `deployment.commit`
+// is Optional+Computed, so Terraform copies the previous state value (the last
+// deployed hash) into the plan when the attribute is not configured. Deploying
+// from the plan would pin that old hash instead of tracking the repository
+// HEAD, only the configuration carries the user intent.
+func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, config, state T) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
 	// Lookup instance by variant slug
@@ -147,7 +152,7 @@ func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, 
 		},
 		Environment:    planEnvironment,
 		VHosts:         vhosts,
-		Deployment:     plan.ToDeployment(resource.GitAuth()),
+		Deployment:     config.ToDeployment(resource.GitAuth()),
 		TriggerRestart: triggerRestart,
 	}
 
@@ -158,6 +163,9 @@ func Update[T RuntimePlan](ctx context.Context, resource RuntimeResource, plan, 
 	// Sync response even if there were errors (app might be updated)
 	if updatedApp != nil {
 		runtime.SetFromResponse(updatedApp, ctx, &diags)
+		resolveUnknownCommit(runtime.Deployment, updatedApp.TargetCommit)
+	} else {
+		resolveUnknownCommit(runtime.Deployment, "")
 	}
 
 	// TCP redirection

--- a/pkg/resources/application/v/crud.go
+++ b/pkg/resources/application/v/crud.go
@@ -33,7 +33,7 @@ func (r *ResourceV) Create(ctx context.Context, req resource.CreateRequest, resp
 	application.SyncNetworkGroups(ctx, r, plan.ID.ValueString(), plan.Networkgroups, &resp.Diagnostics)
 	application.SyncExposedVariables(ctx, r, plan.ID.ValueString(), plan.ExposedEnvironment, &resp.Diagnostics)
 	application.SyncDependencies(ctx, r, plan.ID.ValueString(), plan.Dependencies, &resp.Diagnostics)
-	application.GitDeploy(ctx, plan.ToDeployment(r.GitAuth()), plan.DeployURL.ValueString(), "", &resp.Diagnostics)
+	application.Deploy(ctx, r, &plan, &resp.Diagnostics)
 
 	// Second save: persist secondary operations results
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -76,7 +76,12 @@ func (r *ResourceV) Update(ctx context.Context, req resource.UpdateRequest, res 
 		return
 	}
 
-	res.Diagnostics.Append(application.Update(ctx, r, &plan, &state)...)
+	config := helper.ConfigFrom[V](ctx, req.Config, &res.Diagnostics)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(application.Update(ctx, r, &plan, &config, &state)...)
 
 	// First save: persist changes even if there were partial errors
 	res.Diagnostics.Append(res.State.Set(ctx, plan)...)

--- a/pkg/resources/application/v/schema.go
+++ b/pkg/resources/application/v/schema.go
@@ -3,12 +3,10 @@ package v
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"go.clever-cloud.com/terraform-provider/pkg/attributes"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -77,26 +75,4 @@ func (vapp *V) FromEnv(ctx context.Context, env *maps.Map[string, string], diags
 	pkg.SetBoolIf(&vapp.DevelopmentBuild, env.PopPtr("ENVIRONMENT"), "development")
 
 	vapp.Integrations = attributes.FromEnvIntegrations(ctx, env, vapp.Integrations, diags)
-}
-
-func (vapp V) ToDeployment(gitAuth *http.BasicAuth) *application.Deployment {
-	if vapp.Deployment == nil || vapp.Deployment.Repository.IsNull() {
-		return nil
-	}
-
-	d := &application.Deployment{
-		Repository:    vapp.Deployment.Repository.ValueString(),
-		Commit:        vapp.Deployment.Commit.ValueStringPointer(),
-		CleverGitAuth: gitAuth,
-	}
-
-	if !vapp.Deployment.BasicAuthentication.IsNull() && !vapp.Deployment.BasicAuthentication.IsUnknown() {
-		// Expect validation to be done in the schema valisation step
-		userPass := vapp.Deployment.BasicAuthentication.ValueString()
-		splits := strings.SplitN(userPass, ":", 2)
-		d.Username = &splits[0]
-		d.Password = &splits[1]
-	}
-
-	return d
 }

--- a/pkg/resources/git_test.go
+++ b/pkg/resources/git_test.go
@@ -95,6 +95,8 @@ func TestAccPython_localGit(t *testing.T) {
 			ConfigStateChecks: []statecheck.StateCheck{
 				// Test the state for provider's populated values
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				// the pinned commit is kept as-is in the state
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deployment").AtMapKey("commit"), knownvalue.StringExact(hash.String())),
 			},
 		}},
 	})
@@ -203,6 +205,8 @@ func TestAccApplication_envChangeTriggersNewDeployment(t *testing.T) {
 			Config:       providerBlock.Append(pythonBlock).String(),
 			ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("id"), knownvalue.StringRegexp(regexp.MustCompile(`^app_.*$`))),
+				// no commit configured: the computed value is the deployed hash
+				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("deployment").AtMapKey("commit"), knownvalue.StringRegexp(regexp.MustCompile(`^[0-9a-f]{40}$`))),
 				expectDeployments(1),
 			},
 		}, {


### PR DESCRIPTION
## Summary

`deployment.commit` becomes **Optional + Computed** and now reports the commit actually running on the application. This merges the `deployed_commit` idea from #327 into the existing attribute, as discussed there.

- **Read** fills `deployment.commit` from the API `commitId` when the `deployment` block is managed by Terraform. A deployment done outside Terraform becomes visible in the state — without creating any diff when `commit` is not set in the configuration.
- When the `deployment` block is **absent**, nothing is reconciled: users who don't manage deployments with Terraform never see a diff.
- Git references (`refs/heads/...`) and `github_hook` values are kept as-is (overwriting them with the running hash would fight the configuration), while a pinned commit hash detects drift and re-deploys on the next apply.
- **Create/Update** resolve the unknown planned value with the commit resolved by the git push; `UseStateForUnknown` keeps the state value on subsequent plans (no `(known after apply)` noise).
- **Update now deploys from the configuration instead of the plan**: Terraform copies the previously deployed hash into the plan for optional+computed attributes, deploying from the plan would pin that old hash instead of tracking the repository HEAD.
- Cleanup: the 17 identical `ToDeployment` implementations are factored into a single method on `Runtime`.

Closes #100
Supersedes #327

## Behaviour matrix

| configuration | behaviour |
|---|---|
| no `deployment` block | untouched, never any diff |
| block without `commit` | HEAD is deployed, `commit` reflects the running hash; out-of-band deploys update it silently on refresh |
| `commit = <hash>` | pinned; an out-of-band deploy shows a diff and the next apply re-deploys the pinned hash |
| `commit = refs/heads/...` | kept as-is, no drift detection (the running hash is not comparable to a local ref) |
| `commit = github_hook` | kept as-is, Github-driven deploys never create a diff |

## Tests

- unit tests on both reconciliation helpers (`resolveUnknownCommit`, `syncDeploymentCommit`)
- acceptance (ran locally, all green):
  - `TestAccPython_localGit` — pinned commit kept in state
  - `TestAccApplication_envChangeTriggersNewDeployment` — computed commit is the deployed hash, post-apply plan is empty, restart-on-env-change preserved
  - `TestAccPython_basic` — app without deployment block + app deploying a Github repo HEAD