### PR TITLE
fix(application): add missing v0 state upgraders on rust, frankenphp, dotnet and v

### DIFF
--- a/pkg/helper/configurer.go
+++ b/pkg/helper/configurer.go
@@ -39,6 +39,12 @@ func (c *Configurer) ImportState(ctx context.Context, req resource.ImportStateRe
 	resource.ImportStatePassthroughID(ctx, attr, req, resp)
 }
 
+// UpgradeState is the default for resources still at their first schema version.
+// Bumping a schema Version requires the resource to override this method with an
+// upgrader for every prior version, otherwise Terraform refuses to load any state
+// holding an older instance. TestResources_stateUpgradersCoverEveryPriorVersion
+// in pkg/registry enforces it.
+//
 // https://developer.hashicorp.com/terraform/plugin/framework/resources/state-upgrade#implementing-state-upgrade-support
 func (c *Configurer) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,62 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"go.clever-cloud.com/terraform-provider/pkg/registry"
+)
+
+// Resources whose first published schema version is above 0: no state can exist at
+// the versions below, so no upgrader is expected for them.
+var firstSchemaVersion = map[string]int64{
+	"clevercloud_linux":   1,
+	"clevercloud_haskell": 1,
+}
+
+// Every resource with a schema version above its first published one must ship a
+// state upgrader for each prior version. Without it, Terraform refuses to load any
+// state holding an older instance and blocks every operation (#265, #433).
+func TestResources_stateUpgradersCoverEveryPriorVersion(t *testing.T) {
+	ctx := t.Context()
+	seen := map[string]bool{}
+
+	for _, newResource := range registry.Resources {
+		r := newResource()
+
+		meta := resource.MetadataResponse{}
+		r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "clevercloud"}, &meta)
+		seen[meta.TypeName] = true
+
+		sch := resource.SchemaResponse{}
+		r.Schema(ctx, resource.SchemaRequest{}, &sch)
+
+		first := firstSchemaVersion[meta.TypeName]
+		if sch.Schema.Version < first {
+			t.Errorf("%s: firstSchemaVersion says %d but schema version is %d", meta.TypeName, first, sch.Schema.Version)
+			continue
+		}
+
+		upgraders := map[int64]resource.StateUpgrader{}
+		if withUpgrade, ok := r.(resource.ResourceWithUpgradeState); ok {
+			upgraders = withUpgrade.UpgradeState(ctx)
+		}
+
+		for version := first; version < sch.Schema.Version; version++ {
+			if _, ok := upgraders[version]; !ok {
+				t.Errorf("%s: schema version %d but no state upgrader for version %d", meta.TypeName, sch.Schema.Version, version)
+			}
+		}
+		for version := range upgraders {
+			if version >= sch.Schema.Version {
+				t.Errorf("%s: state upgrader for version %d is never called, schema version is %d", meta.TypeName, version, sch.Schema.Version)
+			}
+		}
+	}
+
+	for typeName := range firstSchemaVersion {
+		if !seen[typeName] {
+			t.Errorf("firstSchemaVersion lists %s, which is not a registered resource", typeName)
+		}
+	}
+}

--- a/pkg/resources/application/dotnet/dotnet.go
+++ b/pkg/resources/application/dotnet/dotnet.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
 
@@ -17,6 +19,34 @@ func NewResourceDotnet() resource.Resource {
 
 func (r *ResourceDotnet) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_dotnet"
+}
+
+// UpgradeState implements state migration from version 0 to 1.
+//
+// dotnet was created after vhosts became {fqdn, path_begin} objects, so a version 0
+// state already has the current shape and only lacks the attributes added since
+// (exposed_environment in 1.8.0, integrations in 1.9.0, redirection in 2.1.0). The
+// framework decodes the raw state against the current schema, ignores attributes
+// it does not know and leaves missing ones null, so nothing else needs to change.
+//
+// This holds as long as no existing attribute changes type. If one does in a later
+// schema version, snapshot this schema as it was before the change.
+func (r *ResourceDotnet) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaDotnet,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, res *resource.UpgradeStateResponse) {
+				tflog.Info(ctx, "Upgrading Dotnet resource state from version 0 to 1")
+
+				state := helper.StateFrom[Dotnet](ctx, *req.State, &res.Diagnostics)
+				if res.Diagnostics.HasError() {
+					return
+				}
+
+				res.Diagnostics.Append(res.State.Set(ctx, state)...)
+			},
+		},
+	}
 }
 
 func (r *ResourceDotnet) GetVariantSlug() string {

--- a/pkg/resources/application/dotnet/schema.go
+++ b/pkg/resources/application/dotnet/schema.go
@@ -26,30 +26,32 @@ type Dotnet struct {
 //go:embed doc.md
 var dotnetDoc string
 
+var schemaDotnet = schema.Schema{
+	Version:             1,
+	MarkdownDescription: dotnetDoc,
+	Attributes: application.WithRuntimeCommons(map[string]schema.Attribute{
+		"profile": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Override the build configuration settings in your project. Default: Release",
+		},
+		"proj": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension.",
+		},
+		"tfm": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0",
+		},
+		"version": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Choose the .NET Core version between 6.0, 8.0, 9.0. Default: '8.0'",
+		},
+	}),
+	Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
+}
+
 func (r ResourceDotnet) Schema(ctx context.Context, req resource.SchemaRequest, res *resource.SchemaResponse) {
-	res.Schema = schema.Schema{
-		Version:             1,
-		MarkdownDescription: dotnetDoc,
-		Attributes: application.WithRuntimeCommons(map[string]schema.Attribute{
-			"profile": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Override the build configuration settings in your project. Default: Release",
-			},
-			"proj": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension.",
-			},
-			"tfm": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Compiles for a specific framework. The framework must be defined in the project file. Example : net5.0",
-			},
-			"version": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Choose the .NET Core version between 6.0, 8.0, 9.0. Default: '8.0'",
-			},
-		}),
-		Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
-	}
+	res.Schema = schemaDotnet
 }
 
 func (dotnetapp Dotnet) ToEnv(ctx context.Context, diags *diag.Diagnostics) map[string]string {

--- a/pkg/resources/application/dotnet/upgrade_test.go
+++ b/pkg/resources/application/dotnet/upgrade_test.go
@@ -1,0 +1,85 @@
+package dotnet_test
+
+import (
+	"maps"
+	"testing"
+
+	"go.clever-cloud.com/terraform-provider/pkg/tests"
+)
+
+// State written by provider 1.3.0 (schema version 0): the runtime was created after
+// the vhosts refactor, so vhosts are already {fqdn, path_begin} objects. Only the
+// attributes added later are missing.
+const dotnetStateV0 = `{
+  "id": "app_2c3d4e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f",
+  "name": "api",
+  "description": "dotnet api",
+  "min_instance_count": 1,
+  "max_instance_count": 3,
+  "smallest_flavor": "S",
+  "biggest_flavor": "L",
+  "build_flavor": null,
+  "region": "par",
+  "sticky_sessions": false,
+  "redirect_https": true,
+  "vhosts": [{"fqdn": "api.example.com", "path_begin": "/"}, {"fqdn": "admin.example.com", "path_begin": "/v2"}],
+  "app_folder": null,
+  "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_2c3d4e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f.git",
+  "environment": {"ASPNETCORE_ENVIRONMENT": "Production"},
+  "dependencies": [],
+  "profile": "Release",
+  "proj": "Api",
+  "tfm": "net8.0",
+  "version": "8.0",
+  "deployment": {"repository": "https://github.com/example/api.git", "commit": "0123456789abcdef0123456789abcdef01234567"},
+  "hooks": {"pre_build": null, "post_build": "dotnet test", "pre_run": null, "run_succeed": null, "run_failed": null}
+}`
+
+// State written by provider 1.6.0 to 1.7.x, still schema version 0 but with the
+// networkgroups attribute that arrived in the meantime.
+const dotnetStateV0WithNetworkgroups = `{
+  "id": "app_2c3d4e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f",
+  "name": "api",
+  "region": "par",
+  "vhosts": [{"fqdn": "api.example.com", "path_begin": "/"}],
+  "networkgroups": [{"networkgroup_id": "ng_3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d", "fqdn": "api.ng.example.com"}],
+  "version": "8.0"
+}`
+
+func TestDotnet_UpgradeStateV0(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_dotnet", 0, dotnetStateV0)
+
+	// vhosts were already nested objects, they must go through untouched
+	wantVHosts := map[string]string{"api.example.com": "/", "admin.example.com": "/v2"}
+	if got := tests.StateVHosts(t, state); !maps.Equal(got, wantVHosts) {
+		t.Errorf("vhosts = %v, want %v", got, wantVHosts)
+	}
+	if got := tests.StateString(t, state, "version"); got != "8.0" {
+		t.Errorf("version = %q, want 8.0", got)
+	}
+	if got := tests.StateString(t, state, "proj"); got != "Api" {
+		t.Errorf("proj = %q, want Api", got)
+	}
+	if got := tests.StateNestedString(t, state, "deployment", "commit"); got != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("deployment.commit = %q", got)
+	}
+	if got := tests.StateNestedString(t, state, "hooks", "post_build"); got != "dotnet test" {
+		t.Errorf("hooks.post_build = %q", got)
+	}
+	if !tests.StateAttr(t, state, "exposed_environment").IsNull() {
+		t.Error("exposed_environment should be null after upgrade")
+	}
+	if !tests.StateAttr(t, state, "networkgroups").IsNull() {
+		t.Error("networkgroups should be null when absent from the old state")
+	}
+}
+
+func TestDotnet_UpgradeStateV0_keepsNetworkgroups(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_dotnet", 0, dotnetStateV0WithNetworkgroups)
+
+	got := tests.StateObjects(t, state, "networkgroups")
+	want := []map[string]string{{"networkgroup_id": "ng_3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d", "fqdn": "api.ng.example.com"}}
+	if len(got) != 1 || !maps.Equal(got[0], want[0]) {
+		t.Errorf("networkgroups = %v, want %v", got, want)
+	}
+}

--- a/pkg/resources/application/frankenphp/frankenphp.go
+++ b/pkg/resources/application/frankenphp/frankenphp.go
@@ -4,6 +4,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
 
@@ -17,6 +20,62 @@ func NewResourceFrankenPHP() resource.Resource {
 
 func (r *ResourceFrankenPHP) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_frankenphp"
+}
+
+// UpgradeState implements state migration from version 0 to 1: vhosts turn from
+// "fqdn/path" strings into {fqdn, path_begin} objects, and the attributes added since
+// (networkgroups, exposed_environment, integrations, redirection) start out null.
+func (r *ResourceFrankenPHP) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaFrankenPHPV0,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, res *resource.UpgradeStateResponse) {
+				tflog.Info(ctx, "Upgrading FrankenPHP resource state from version 0 to 1")
+
+				old := helper.StateFrom[FrankenPHPV0](ctx, *req.State, &res.Diagnostics)
+				if res.Diagnostics.HasError() {
+					return
+				}
+
+				oldVhosts := []string{}
+				res.Diagnostics.Append(old.VHosts.ElementsAs(ctx, &oldVhosts, false)...)
+				if res.Diagnostics.HasError() {
+					return
+				}
+				vhosts := helper.VHostsFromAPIHosts(ctx, oldVhosts, old.VHosts, &res.Diagnostics)
+
+				newState := FrankenPHP{
+					Runtime: application.Runtime{
+						ID:                 old.ID,
+						Name:               old.Name,
+						Description:        old.Description,
+						MinInstanceCount:   old.MinInstanceCount,
+						MaxInstanceCount:   old.MaxInstanceCount,
+						SmallestFlavor:     old.SmallestFlavor,
+						BiggestFlavor:      old.BiggestFlavor,
+						BuildFlavor:        old.BuildFlavor,
+						Region:             old.Region,
+						StickySessions:     old.StickySessions,
+						RedirectHTTPS:      old.RedirectHTTPS,
+						VHosts:             vhosts,
+						DeployURL:          old.DeployURL,
+						Dependencies:       old.Dependencies,
+						Deployment:         old.Deployment,
+						Hooks:              old.Hooks,
+						Integrations:       nil,
+						Redirection:        nil,
+						AppFolder:          old.AppFolder,
+						Environment:        old.Environment,
+						Networkgroups:      resources.NullNetworkgroupConfig,
+						ExposedEnvironment: application.NullExposedEnv,
+					},
+					DevDependencies: old.DevDependencies,
+				}
+
+				res.Diagnostics.Append(res.State.Set(ctx, newState)...)
+			},
+		},
+	}
 }
 
 func (r *ResourceFrankenPHP) GetVariantSlug() string {

--- a/pkg/resources/application/frankenphp/schema.go
+++ b/pkg/resources/application/frankenphp/schema.go
@@ -21,8 +21,30 @@ type FrankenPHP struct {
 	DevDependencies types.Bool `tfsdk:"dev_dependencies"`
 }
 
+// FrankenPHPV0 is the schema version 0 shape of FrankenPHP, kept for state upgrades
+type FrankenPHPV0 struct {
+	application.RuntimeV0
+	DevDependencies types.Bool `tfsdk:"dev_dependencies"`
+}
+
 //go:embed doc.md
 var frankenphpDoc string
+
+// schemaFrankenPHPV0 is the schema version 0 as shipped in 1.1.0, before vhosts became
+// {fqdn, path_begin} objects. Frozen: it must keep decoding states written back then.
+var schemaFrankenPHPV0 = schema.Schema{
+	Version:             0,
+	MarkdownDescription: frankenphpDoc,
+	Attributes: application.WithRuntimeCommonsV0(map[string]schema.Attribute{
+		"dev_dependencies": schema.BoolAttribute{
+			Optional:            true,
+			Computed:            true,
+			MarkdownDescription: "Install development dependencies (Default: false)",
+			Default:             booldefault.StaticBool(false),
+		},
+	}),
+	Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
+}
 
 func (r ResourceFrankenPHP) Schema(ctx context.Context, req resource.SchemaRequest, res *resource.SchemaResponse) {
 	res.Schema = schema.Schema{

--- a/pkg/resources/application/frankenphp/upgrade_test.go
+++ b/pkg/resources/application/frankenphp/upgrade_test.go
@@ -1,0 +1,73 @@
+package frankenphp_test
+
+import (
+	"maps"
+	"testing"
+
+	"go.clever-cloud.com/terraform-provider/pkg/tests"
+)
+
+// State written by provider 1.1.0 (schema version 0): vhosts is a set of
+// "fqdn/path" strings, none of the attributes added since exist.
+const frankenphpStateV0 = `{
+  "id": "app_9b8a7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d",
+  "name": "website",
+  "description": null,
+  "min_instance_count": 1,
+  "max_instance_count": 1,
+  "smallest_flavor": "S",
+  "biggest_flavor": "S",
+  "build_flavor": "M",
+  "region": "par",
+  "sticky_sessions": true,
+  "redirect_https": true,
+  "vhosts": ["www.example.com/", "example.com/"],
+  "app_folder": "site",
+  "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_9b8a7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d.git",
+  "environment": {},
+  "dependencies": ["addon_1f2e3d4c-5b6a-4978-8f9e-0a1b2c3d4e5f"],
+  "dev_dependencies": true,
+  "deployment": {"repository": "https://github.com/example/site.git", "commit": null},
+  "hooks": {"pre_build": "composer install", "post_build": null, "pre_run": null, "run_succeed": null, "run_failed": null}
+}`
+
+func TestFrankenPHP_UpgradeStateV0(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_frankenphp", 0, frankenphpStateV0)
+
+	wantVHosts := map[string]string{"www.example.com": "/", "example.com": "/"}
+	if got := tests.StateVHosts(t, state); !maps.Equal(got, wantVHosts) {
+		t.Errorf("vhosts = %v, want %v", got, wantVHosts)
+	}
+	if got := tests.StateString(t, state, "app_folder"); got != "site" {
+		t.Errorf("app_folder = %q, want site", got)
+	}
+
+	var devDeps bool
+	if err := tests.StateAttr(t, state, "dev_dependencies").As(&devDeps); err != nil || !devDeps {
+		t.Errorf("dev_dependencies = %v (%v), want true", devDeps, err)
+	}
+	if !tests.StateAttr(t, state, "exposed_environment").IsNull() {
+		t.Error("exposed_environment should be null after upgrade")
+	}
+}
+
+func TestFrankenPHP_UpgradeStateV0_keepsBlocks(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_frankenphp", 0, frankenphpStateV0)
+
+	if got := tests.StateNestedString(t, state, "deployment", "repository"); got != "https://github.com/example/site.git" {
+		t.Errorf("deployment.repository = %q", got)
+	}
+	if got := tests.StateNestedString(t, state, "hooks", "pre_build"); got != "composer install" {
+		t.Errorf("hooks.pre_build = %q", got)
+	}
+}
+
+func TestFrankenPHP_UpgradeStateV0_nullVHosts(t *testing.T) {
+	raw := `{"id": "app_x", "name": "website", "region": "par", "vhosts": null}`
+
+	state := tests.UpgradeResourceState(t, "clevercloud_frankenphp", 0, raw)
+
+	if got := tests.StateVHosts(t, state); got != nil {
+		t.Errorf("vhosts = %v, want null", got)
+	}
+}

--- a/pkg/resources/application/rust/rust.go
+++ b/pkg/resources/application/rust/rust.go
@@ -4,6 +4,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/helper"
+	"go.clever-cloud.com/terraform-provider/pkg/resources"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
 
@@ -17,6 +20,62 @@ func NewResourceRust() resource.Resource {
 
 func (r *ResourceRust) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_rust"
+}
+
+// UpgradeState implements state migration from version 0 to 1: vhosts turn from
+// "fqdn/path" strings into {fqdn, path_begin} objects, and the attributes added since
+// (networkgroups, exposed_environment, integrations, redirection) start out null.
+func (r *ResourceRust) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaRustV0,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, res *resource.UpgradeStateResponse) {
+				tflog.Info(ctx, "Upgrading Rust resource state from version 0 to 1")
+
+				old := helper.StateFrom[RustV0](ctx, *req.State, &res.Diagnostics)
+				if res.Diagnostics.HasError() {
+					return
+				}
+
+				oldVhosts := []string{}
+				res.Diagnostics.Append(old.VHosts.ElementsAs(ctx, &oldVhosts, false)...)
+				if res.Diagnostics.HasError() {
+					return
+				}
+				vhosts := helper.VHostsFromAPIHosts(ctx, oldVhosts, old.VHosts, &res.Diagnostics)
+
+				newState := Rust{
+					Runtime: application.Runtime{
+						ID:                 old.ID,
+						Name:               old.Name,
+						Description:        old.Description,
+						MinInstanceCount:   old.MinInstanceCount,
+						MaxInstanceCount:   old.MaxInstanceCount,
+						SmallestFlavor:     old.SmallestFlavor,
+						BiggestFlavor:      old.BiggestFlavor,
+						BuildFlavor:        old.BuildFlavor,
+						Region:             old.Region,
+						StickySessions:     old.StickySessions,
+						RedirectHTTPS:      old.RedirectHTTPS,
+						VHosts:             vhosts,
+						DeployURL:          old.DeployURL,
+						Dependencies:       old.Dependencies,
+						Deployment:         old.Deployment,
+						Hooks:              old.Hooks,
+						Integrations:       nil,
+						Redirection:        nil,
+						AppFolder:          old.AppFolder,
+						Environment:        old.Environment,
+						Networkgroups:      resources.NullNetworkgroupConfig,
+						ExposedEnvironment: application.NullExposedEnv,
+					},
+					Features: old.Features,
+				}
+
+				res.Diagnostics.Append(res.State.Set(ctx, newState)...)
+			},
+		},
+	}
 }
 
 const CC_RUST_FEATURES = "CC_RUST_FEATURES"

--- a/pkg/resources/application/rust/schema.go
+++ b/pkg/resources/application/rust/schema.go
@@ -21,6 +21,12 @@ type Rust struct {
 	Features types.Set `tfsdk:"features"`
 }
 
+// RustV0 is the schema version 0 shape of Rust, kept for state upgrades
+type RustV0 struct {
+	application.RuntimeV0
+	Features types.Set `tfsdk:"features"`
+}
+
 func (r Rust) FeaturesAsStrings(ctx context.Context, diags *diag.Diagnostics) []string {
 	features := []string{}
 	diags.Append(r.Features.ElementsAs(ctx, &features, true)...)
@@ -29,6 +35,21 @@ func (r Rust) FeaturesAsStrings(ctx context.Context, diags *diag.Diagnostics) []
 
 //go:embed doc.md
 var rustDoc string
+
+// schemaRustV0 is the schema version 0 as shipped up to 1.1.0, before vhosts became
+// {fqdn, path_begin} objects. Frozen: it must keep decoding states written back then.
+var schemaRustV0 = schema.Schema{
+	Version:             0,
+	MarkdownDescription: rustDoc,
+	Attributes: application.WithRuntimeCommonsV0(map[string]schema.Attribute{
+		"features": schema.SetAttribute{
+			ElementType:         types.StringType,
+			Optional:            true,
+			MarkdownDescription: "List of Rust features to enable during build",
+		},
+	}),
+	Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
+}
 
 func (r ResourceRust) Schema(ctx context.Context, req resource.SchemaRequest, res *resource.SchemaResponse) {
 	res.Schema = schema.Schema{

--- a/pkg/resources/application/rust/upgrade_test.go
+++ b/pkg/resources/application/rust/upgrade_test.go
@@ -1,0 +1,61 @@
+package rust_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"go.clever-cloud.com/terraform-provider/pkg/tests"
+)
+
+// State written by provider <= 1.1.0 (schema version 0): vhosts is a set of
+// "fqdn/path" strings, none of the attributes added since exist.
+const rustStateV0 = `{
+  "id": "app_5e7d2c1a-8f3b-4c6e-9a1d-2b3c4d5e6f70",
+  "name": "enhancer",
+  "description": "access logs enhancer",
+  "min_instance_count": 1,
+  "max_instance_count": 2,
+  "smallest_flavor": "XS",
+  "biggest_flavor": "M",
+  "build_flavor": null,
+  "region": "par",
+  "sticky_sessions": false,
+  "redirect_https": true,
+  "vhosts": ["console.example.com/", "api.example.com/v1"],
+  "app_folder": null,
+  "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_5e7d2c1a-8f3b-4c6e-9a1d-2b3c4d5e6f70.git",
+  "environment": {"RUST_LOG": "info"},
+  "dependencies": [],
+  "features": ["tls"],
+  "deployment": null,
+  "hooks": null
+}`
+
+func TestRust_UpgradeStateV0(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_rust", 0, rustStateV0)
+
+	wantVHosts := map[string]string{"console.example.com": "/", "api.example.com": "/v1"}
+	if got := tests.StateVHosts(t, state); !maps.Equal(got, wantVHosts) {
+		t.Errorf("vhosts = %v, want %v", got, wantVHosts)
+	}
+	if got := tests.StateString(t, state, "name"); got != "enhancer" {
+		t.Errorf("name = %q, want enhancer", got)
+	}
+	if got := tests.StateStrings(t, state, "features"); !slices.Equal(got, []string{"tls"}) {
+		t.Errorf("features = %v, want [tls]", got)
+	}
+	if !tests.StateAttr(t, state, "exposed_environment").IsNull() {
+		t.Error("exposed_environment should be null after upgrade")
+	}
+}
+
+func TestRust_UpgradeStateV0_nullVHosts(t *testing.T) {
+	raw := `{"id": "app_x", "name": "enhancer", "region": "par", "vhosts": null, "features": null}`
+
+	state := tests.UpgradeResourceState(t, "clevercloud_rust", 0, raw)
+
+	if got := tests.StateVHosts(t, state); got != nil {
+		t.Errorf("vhosts = %v, want null", got)
+	}
+}

--- a/pkg/resources/application/v/schema.go
+++ b/pkg/resources/application/v/schema.go
@@ -25,24 +25,26 @@ type V struct {
 //go:embed doc.md
 var vDoc string
 
+var schemaV = schema.Schema{
+	Version:             1,
+	MarkdownDescription: vDoc,
+	Attributes: application.WithRuntimeCommons(map[string]schema.Attribute{
+		"binary": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "The name of the output binary file. Default: `${APP_HOME}/v_bin_${APP_ID}`",
+		},
+		"development_build": schema.BoolAttribute{
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Set to true to compile without the `-prod` flag.",
+		},
+	}),
+	Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
+}
+
 func (r ResourceV) Schema(ctx context.Context, req resource.SchemaRequest, res *resource.SchemaResponse) {
-	res.Schema = schema.Schema{
-		Version:             1,
-		MarkdownDescription: vDoc,
-		Attributes: application.WithRuntimeCommons(map[string]schema.Attribute{
-			"binary": schema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "The name of the output binary file. Default: `${APP_HOME}/v_bin_${APP_ID}`",
-			},
-			"development_build": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-				MarkdownDescription: "Set to true to compile without the `-prod` flag.",
-			},
-		}),
-		Blocks: attributes.WithBlockRuntimeCommons(map[string]schema.Block{}),
-	}
+	res.Schema = schemaV
 }
 
 func (vapp V) ToEnv(ctx context.Context, diags *diag.Diagnostics) map[string]string {

--- a/pkg/resources/application/v/upgrade_test.go
+++ b/pkg/resources/application/v/upgrade_test.go
@@ -1,0 +1,81 @@
+package v_test
+
+import (
+	"maps"
+	"testing"
+
+	"go.clever-cloud.com/terraform-provider/pkg/tests"
+)
+
+// State written by provider 1.3.0 (schema version 0): the runtime was created after
+// the vhosts refactor, so vhosts are already {fqdn, path_begin} objects. Only the
+// attributes added later are missing.
+const vStateV0 = `{
+  "id": "app_7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
+  "name": "vweb",
+  "description": null,
+  "min_instance_count": 1,
+  "max_instance_count": 1,
+  "smallest_flavor": "XS",
+  "biggest_flavor": "XS",
+  "build_flavor": null,
+  "region": "par",
+  "sticky_sessions": false,
+  "redirect_https": false,
+  "vhosts": [{"fqdn": "v.example.com", "path_begin": "/"}],
+  "app_folder": "web",
+  "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d.git",
+  "environment": {},
+  "dependencies": [],
+  "binary": "server",
+  "development_build": true,
+  "deployment": {"repository": "https://github.com/example/vweb.git", "commit": null},
+  "hooks": {"pre_build": null, "post_build": null, "pre_run": "v -version", "run_succeed": null, "run_failed": null}
+}`
+
+// State written by provider 1.6.0 to 1.7.x, still schema version 0 but with the
+// networkgroups attribute that arrived in the meantime.
+const vStateV0WithNetworkgroups = `{
+  "id": "app_7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
+  "name": "vweb",
+  "region": "par",
+  "vhosts": [{"fqdn": "v.example.com", "path_begin": "/"}],
+  "networkgroups": [{"networkgroup_id": "ng_3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d", "fqdn": "vweb.ng.example.com"}],
+  "binary": "server"
+}`
+
+func TestV_UpgradeStateV0(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_v", 0, vStateV0)
+
+	// vhosts were already nested objects, they must go through untouched
+	wantVHosts := map[string]string{"v.example.com": "/"}
+	if got := tests.StateVHosts(t, state); !maps.Equal(got, wantVHosts) {
+		t.Errorf("vhosts = %v, want %v", got, wantVHosts)
+	}
+	if got := tests.StateString(t, state, "binary"); got != "server" {
+		t.Errorf("binary = %q, want server", got)
+	}
+	var devBuild bool
+	if err := tests.StateAttr(t, state, "development_build").As(&devBuild); err != nil || !devBuild {
+		t.Errorf("development_build = %v (%v), want true", devBuild, err)
+	}
+	if got := tests.StateNestedString(t, state, "deployment", "repository"); got != "https://github.com/example/vweb.git" {
+		t.Errorf("deployment.repository = %q", got)
+	}
+	if got := tests.StateNestedString(t, state, "hooks", "pre_run"); got != "v -version" {
+		t.Errorf("hooks.pre_run = %q", got)
+	}
+	if !tests.StateAttr(t, state, "exposed_environment").IsNull() {
+		t.Error("exposed_environment should be null after upgrade")
+	}
+}
+
+func TestV_UpgradeStateV0_keepsNetworkgroups(t *testing.T) {
+	state := tests.UpgradeResourceState(t, "clevercloud_v", 0, vStateV0WithNetworkgroups)
+
+	got := tests.StateObjects(t, state, "networkgroups")
+	want := []map[string]string{{"networkgroup_id": "ng_3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d", "fqdn": "vweb.ng.example.com"}}
+	if len(got) != 1 || !maps.Equal(got[0], want[0]) {
+		t.Errorf("networkgroups = %v, want %v", got, want)
+	}
+}

--- a/pkg/resources/application/v/v.go
+++ b/pkg/resources/application/v/v.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"go.clever-cloud.com/terraform-provider/pkg/helper"
 	"go.clever-cloud.com/terraform-provider/pkg/resources/application"
 )
 
@@ -17,6 +19,34 @@ func NewResourceV() resource.Resource {
 
 func (r *ResourceV) Metadata(ctx context.Context, req resource.MetadataRequest, res *resource.MetadataResponse) {
 	res.TypeName = req.ProviderTypeName + "_v"
+}
+
+// UpgradeState implements state migration from version 0 to 1.
+//
+// v was created after vhosts became {fqdn, path_begin} objects, so a version 0
+// state already has the current shape and only lacks the attributes added since
+// (exposed_environment in 1.8.0, integrations in 1.9.0, redirection in 2.1.0). The
+// framework decodes the raw state against the current schema, ignores attributes
+// it does not know and leaves missing ones null, so nothing else needs to change.
+//
+// This holds as long as no existing attribute changes type. If one does in a later
+// schema version, snapshot this schema as it was before the change.
+func (r *ResourceV) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaV,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, res *resource.UpgradeStateResponse) {
+				tflog.Info(ctx, "Upgrading V resource state from version 0 to 1")
+
+				state := helper.StateFrom[V](ctx, *req.State, &res.Diagnostics)
+				if res.Diagnostics.HasError() {
+					return
+				}
+
+				res.Diagnostics.Append(res.State.Set(ctx, state)...)
+			},
+		},
+	}
 }
 
 func (r *ResourceV) GetVariantSlug() string {

--- a/pkg/tests/upgrade.go
+++ b/pkg/tests/upgrade.go
@@ -1,0 +1,168 @@
+package tests
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// UpgradeResourceState replays the UpgradeResourceState RPC Terraform issues when a
+// stored instance carries a schema_version older than the resource schema.
+// rawJSON is the instance "attributes" object as found in a state file.
+// The upgraded state is decoded against the current resource schema.
+func UpgradeResourceState(t *testing.T, typeName string, fromVersion int64, rawJSON string) tftypes.Value {
+	t.Helper()
+	ctx := t.Context()
+
+	server, err := ProtoV6Provider["clevercloud"]()
+	if err != nil {
+		t.Fatalf("provider server: %s", err)
+	}
+
+	res, err := server.UpgradeResourceState(ctx, &tfprotov6.UpgradeResourceStateRequest{
+		TypeName: typeName,
+		Version:  fromVersion,
+		RawState: &tfprotov6.RawState{JSON: []byte(rawJSON)},
+	})
+	if err != nil {
+		t.Fatalf("UpgradeResourceState(%s): %s", typeName, err)
+	}
+	for _, d := range res.Diagnostics {
+		if d.Severity == tfprotov6.DiagnosticSeverityError {
+			t.Fatalf("UpgradeResourceState(%s): %s: %s", typeName, d.Summary, d.Detail)
+		}
+	}
+
+	schemas, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %s", err)
+	}
+	schema, ok := schemas.ResourceSchemas[typeName]
+	if !ok {
+		t.Fatalf("no schema registered for %s", typeName)
+	}
+
+	state, err := res.UpgradedState.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatalf("decode upgraded state of %s: %s", typeName, err)
+	}
+	return state
+}
+
+// StateAttr returns one top-level attribute of a decoded state.
+func StateAttr(t *testing.T, state tftypes.Value, name string) tftypes.Value {
+	t.Helper()
+
+	attrs := map[string]tftypes.Value{}
+	if err := state.As(&attrs); err != nil {
+		t.Fatalf("state is not an object: %s", err)
+	}
+	v, ok := attrs[name]
+	if !ok {
+		t.Fatalf("no attribute %q in state", name)
+	}
+	return v
+}
+
+// StateString returns a known, non-null string attribute.
+func StateString(t *testing.T, state tftypes.Value, name string) string {
+	t.Helper()
+
+	var s string
+	if err := StateAttr(t, state, name).As(&s); err != nil {
+		t.Fatalf("attribute %q: %s", name, err)
+	}
+	return s
+}
+
+// StateNestedString returns a known, non-null string attribute of a nested object
+// or block, such as deployment.repository.
+func StateNestedString(t *testing.T, state tftypes.Value, object, name string) string {
+	t.Helper()
+
+	attrs := map[string]tftypes.Value{}
+	if err := StateAttr(t, state, object).As(&attrs); err != nil {
+		t.Fatalf("%s: %s", object, err)
+	}
+	var s string
+	if err := attrs[name].As(&s); err != nil {
+		t.Fatalf("%s.%s: %s", object, name, err)
+	}
+	return s
+}
+
+// StateStrings returns a set or list of strings attribute, sorted, nil when null.
+func StateStrings(t *testing.T, state tftypes.Value, name string) []string {
+	t.Helper()
+
+	v := StateAttr(t, state, name)
+	if v.IsNull() {
+		return nil
+	}
+	elems := []tftypes.Value{}
+	if err := v.As(&elems); err != nil {
+		t.Fatalf("attribute %q: %s", name, err)
+	}
+	out := []string{}
+	for _, e := range elems {
+		var s string
+		if err := e.As(&s); err != nil {
+			t.Fatalf("attribute %q element: %s", name, err)
+		}
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// StateObjects returns a set or list of objects attribute as one map per element,
+// holding its non-null string attributes. nil when null.
+func StateObjects(t *testing.T, state tftypes.Value, name string) []map[string]string {
+	t.Helper()
+
+	v := StateAttr(t, state, name)
+	if v.IsNull() {
+		return nil
+	}
+	elems := []tftypes.Value{}
+	if err := v.As(&elems); err != nil {
+		t.Fatalf("attribute %q: %s", name, err)
+	}
+	out := []map[string]string{}
+	for _, e := range elems {
+		obj := map[string]tftypes.Value{}
+		if err := e.As(&obj); err != nil {
+			t.Fatalf("attribute %q element: %s", name, err)
+		}
+		m := map[string]string{}
+		for k, av := range obj {
+			if av.IsNull() {
+				continue
+			}
+			var s string
+			if err := av.As(&s); err != nil {
+				t.Fatalf("attribute %q element %q: %s", name, k, err)
+			}
+			m[k] = s
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// StateVHosts returns the vhosts attribute as fqdn -> path_begin, nil when null.
+func StateVHosts(t *testing.T, state tftypes.Value) map[string]string {
+	t.Helper()
+
+	objects := StateObjects(t, state, "vhosts")
+	if objects == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, vhost := range objects {
+		out[vhost["fqdn"]] = vhost["path_begin"]
+	}
+	return out
+}


### PR DESCRIPTION
Closes #433

## Problem

`clevercloud_rust`, `clevercloud_frankenphp`, `clevercloud_dotnet` and `clevercloud_v` declare schema `Version: 1` but never shipped a state upgrader for version 0. Every application resource embeds `helper.Configurer`, whose `UpgradeState()` returns an empty map, so the framework fails with:

```
Unable to Upgrade Resource State
This resource was implemented with an UpgradeState() method, however Terraform
was expecting an implementation for version 0 upgrade.
```

Terraform upgrades every instance before acting, so a single old instance blocks plan, apply and import of unrelated resources. Same class as #265, which fixed python only.

## Two shapes of v0 state

| Runtime | v0 written by | v0 `vhosts` | Upgrader |
|---|---|---|---|
| rust, frankenphp | ≤ 1.1.0 | set of `"fqdn/path"` strings | nodejs pattern: `WithRuntimeCommonsV0` + `helper.VHostsFromAPIHosts` |
| dotnet, v | 1.3.0 → 1.7.x | already `{fqdn, path_begin}` objects | pass-through: decode against the current schema, newer attributes come out null |

`linux` and `haskell` were created at `Version: 1`, no v0 state can exist, nothing added there.

## Tests

- `tests.UpgradeResourceState` replays the `UpgradeResourceState` RPC through `providerserver` on a raw JSON state, the exact path Terraform takes. One test per runtime with a state as the old provider wrote it.
- `TestResources_stateUpgradersCoverEveryPriorVersion` walks every registered resource and fails when a schema version has no upgrader for a prior version. Resources born above version 0 are listed explicitly. This is the guard against a fourth occurrence.

One commit per runtime, then the test.

## Not verified locally

`make test` on this machine cannot install the Terraform CLI for the `pkg/provider/impl` acceptance-style tests (`openpgp: key expired`), unrelated to this change. `go test ./... -skip TestAcc` and `go vet ./...` pass.

https://claude.ai/code/session_01Ao1qokk1QRjA33BNKDV8zC
