### PR TITLE
feat(networkgroup): validate member fqdn against the platform DNS suffixes

### DIFF
--- a/docs/resources/docker.md
+++ b/docs/resources/docker.md
@@ -186,7 +186,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/dotnet.md
+++ b/docs/resources/dotnet.md
@@ -225,7 +225,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/frankenphp.md
+++ b/docs/resources/frankenphp.md
@@ -170,7 +170,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/go.md
+++ b/docs/resources/go.md
@@ -225,7 +225,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/haskell.md
+++ b/docs/resources/haskell.md
@@ -225,7 +225,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/java_jar.md
+++ b/docs/resources/java_jar.md
@@ -226,7 +226,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/java_war.md
+++ b/docs/resources/java_war.md
@@ -226,7 +226,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/linux.md
+++ b/docs/resources/linux.md
@@ -238,7 +238,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/nodejs.md
+++ b/docs/resources/nodejs.md
@@ -230,7 +230,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/otoroshi.md
+++ b/docs/resources/otoroshi.md
@@ -53,5 +53,5 @@ Learn more about [Otoroshi with LLM](https://www.clever.cloud/developers/doc/add
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup

--- a/docs/resources/php.md
+++ b/docs/resources/php.md
@@ -166,7 +166,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/play2.md
+++ b/docs/resources/play2.md
@@ -225,7 +225,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/python.md
+++ b/docs/resources/python.md
@@ -227,7 +227,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/ruby.md
+++ b/docs/resources/ruby.md
@@ -312,7 +312,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/rust.md
+++ b/docs/resources/rust.md
@@ -226,7 +226,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/scala.md
+++ b/docs/resources/scala.md
@@ -225,7 +225,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/static.md
+++ b/docs/resources/static.md
@@ -228,7 +228,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/static_apache.md
+++ b/docs/resources/static_apache.md
@@ -261,7 +261,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/docs/resources/v.md
+++ b/docs/resources/v.md
@@ -223,7 +223,7 @@ Optional:
 
 Required:
 
-- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup
+- `fqdn` (String) domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)
 - `networkgroup_id` (String) ID of the networkgroup
 
 

--- a/pkg/resources/application/python/python_test.go
+++ b/pkg/resources/application/python/python_test.go
@@ -338,6 +338,7 @@ func TestAccPython_networkgroup(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	cc := client.New(client.WithAutoOauthConfig())
+	memberFQDN := tests.NGMemberFQDN(t, "myapp")
 	rName := acctest.RandomWithPrefix("tf-test-python")
 	ngName := acctest.RandomWithPrefix("tf-test-python-ng")
 	fullName := fmt.Sprintf("clevercloud_python.%s", rName)
@@ -366,7 +367,7 @@ func TestAccPython_networkgroup(t *testing.T) {
 			"biggest_flavor":     "M",
 			"networkgroups": []map[string]string{{
 				"networkgroup_id": fmt.Sprintf("${clevercloud_networkgroup.%s.id}", ngName),
-				"fqdn":            "myapp",
+				"fqdn":            memberFQDN,
 			}}}),
 	)
 
@@ -402,7 +403,7 @@ func TestAccPython_networkgroup(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("networkgroups"), knownvalue.SetExact([]knownvalue.Check{
 					knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"networkgroup_id": knownvalue.StringRegexp(regexp.MustCompile("^ng_.*$")),
-						"fqdn":            knownvalue.StringExact("myapp"),
+						"fqdn":            knownvalue.StringExact(memberFQDN),
 					}),
 				})),
 			},

--- a/pkg/resources/networkgroup/ng_test.go
+++ b/pkg/resources/networkgroup/ng_test.go
@@ -60,6 +60,7 @@ func TestAccNG_withPeers(t *testing.T) {
 	appName := acctest.RandomWithPrefix("tf-test-docker")
 	ngFullName := fmt.Sprintf("clevercloud_networkgroup.%s", ngName)
 	appFullName := fmt.Sprintf("clevercloud_docker.%s", appName)
+	memberFQDN := tests.NGMemberFQDN(t, "myapp")
 
 	providerBlock := helper.NewProvider("clevercloud").SetOrganisation(tests.ORGANISATION)
 	ngBlock := helper.NewRessource(
@@ -86,7 +87,7 @@ func TestAccNG_withPeers(t *testing.T) {
 			"biggest_flavor":     "XS",
 			"networkgroups": []map[string]string{{
 				"networkgroup_id": fmt.Sprintf("${clevercloud_networkgroup.%s.id}", ngName),
-				"fqdn":            "myapp",
+				"fqdn":            memberFQDN,
 			}},
 		}),
 		helper.SetBlockValues("deployment", map[string]any{

--- a/pkg/resources/ng.go
+++ b/pkg/resources/ng.go
@@ -2,6 +2,10 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -12,6 +16,7 @@ import (
 	"go.clever-cloud.com/terraform-provider/pkg"
 	"go.clever-cloud.com/terraform-provider/pkg/provider"
 	"go.clever-cloud.com/terraform-provider/pkg/tmp"
+	"go.clever-cloud.dev/client"
 	"go.clever-cloud.dev/sdk"
 	"go.clever-cloud.dev/sdk/models"
 )
@@ -41,7 +46,7 @@ var NetworkgroupsAttribute = schema.SetNestedAttribute{
 			},
 			"fqdn": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "domain name which will resolve to application instances inside the networkgroup",
+				MarkdownDescription: "domain name which will resolve to application instances inside the networkgroup; must end with a dot followed by one of the platform DNS suffixes served on `GET /networkgroup/configuration` (`cc-ng.cloud` on the public platform)",
 			},
 		},
 	},
@@ -147,7 +152,20 @@ func SyncNetworkGroups(
 		tflog.Info(ctx, "removed member from NG")
 	}
 
-	for ng := range expectedNG.Difference(currentNG).Iter() {
+	missingNG := expectedNG.Difference(currentNG)
+
+	// Validate the FQDNs of the members about to be created: the platform
+	// rejects a domain name outside its allowed suffixes, and its 400 does not
+	// name them. Only members being (re)created are checked, so an existing
+	// member with a legacy name never blocks an apply.
+	if missingNG.Size() > 0 {
+		validateMemberFQDNs(ctx, prov, missingNG.Slice(), ngIDToFQDN, diags)
+		if diags.HasError() {
+			return
+		}
+	}
+
+	for ng := range missingNG.Iter() {
 		addRes := sdkClient.
 			V4().
 			Networkgroups().
@@ -162,7 +180,51 @@ func SyncNetworkGroups(
 				DomainName: ngIDToFQDN[ng],
 			})
 		if addRes.HasError() {
-			diags.AddError("failed to add member to NG", addRes.Error().Error())
+			detail := addRes.Error().Error()
+			var apiErr *client.APIError
+			if errors.As(addRes.Error(), &apiErr) && len(apiErr.Context) > 0 {
+				// the field-level validation detail only lives in the error context
+				detail = fmt.Sprintf("%s %v", apiErr.Message, apiErr.Context)
+			}
+			diags.AddError("failed to add member to NG", detail)
+		}
+	}
+}
+
+// validateMemberFQDNs checks the FQDN of each member about to be created against
+// the deployment's allowed DNS suffixes, fetched from the public
+// /networkgroup/configuration route. A deployment predating that route answers
+// 404: validation is then skipped and the create call remains the authority.
+func validateMemberFQDNs(
+	ctx context.Context,
+	prov provider.Provider,
+	ngIDs []string,
+	ngIDToFQDN map[string]string,
+	diags *diag.Diagnostics,
+) {
+	confRes := tmp.GetNetworkgroupConfiguration(ctx, prov.Client())
+	if confRes.HasError() {
+		tflog.Warn(ctx, "cannot fetch the networkgroup configuration, skipping FQDN validation", map[string]any{"error": confRes.Error().Error()})
+		return
+	}
+
+	suffixes := confRes.Payload().DNSSuffixes
+	if len(suffixes) == 0 {
+		return
+	}
+
+	for _, ng := range ngIDs {
+		fqdn := ngIDToFQDN[ng]
+		if !slices.ContainsFunc(suffixes, func(suffix string) bool {
+			return strings.HasSuffix(fqdn, "."+suffix)
+		}) {
+			diags.AddError(
+				"invalid networkgroup member fqdn",
+				fmt.Sprintf(
+					"%q must end with a dot followed by one of the platform DNS suffixes: %s (e.g. %q)",
+					fqdn, strings.Join(suffixes, ", "), "myapp."+suffixes[0],
+				),
+			)
 		}
 	}
 }

--- a/pkg/resources/software/otoroshi/otoroshi_test.go
+++ b/pkg/resources/software/otoroshi/otoroshi_test.go
@@ -73,6 +73,7 @@ func TestAccOtoroshi_networkgroup(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	cc := client.New(client.WithAutoOauthConfig())
+	memberFQDN := tests.NGMemberFQDN(t, "myotoroshi")
 	rName := acctest.RandomWithPrefix("tf-test-otoroshi")
 	ngName := acctest.RandomWithPrefix("tf-test-otoroshi-ng")
 	fullName := fmt.Sprintf("clevercloud_otoroshi.%s", rName)
@@ -96,7 +97,7 @@ func TestAccOtoroshi_networkgroup(t *testing.T) {
 			"region": "par",
 			"networkgroups": []map[string]string{{
 				"networkgroup_id": fmt.Sprintf("${clevercloud_networkgroup.%s.id}", ngName),
-				"fqdn":            "myotoroshi",
+				"fqdn":            memberFQDN,
 			}}}),
 	)
 
@@ -122,7 +123,7 @@ func TestAccOtoroshi_networkgroup(t *testing.T) {
 				statecheck.ExpectKnownValue(fullName, tfjsonpath.New("networkgroups"), knownvalue.SetExact([]knownvalue.Check{
 					knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"networkgroup_id": knownvalue.StringRegexp(regexp.MustCompile("^ng_.*$")),
-						"fqdn":            knownvalue.StringExact("myotoroshi"),
+						"fqdn":            knownvalue.StringExact(memberFQDN),
 					}),
 				})),
 			},

--- a/pkg/tests/ngsuffix.go
+++ b/pkg/tests/ngsuffix.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+)
+
+var (
+	ngSuffixOnce sync.Once
+	ngSuffix     string
+	ngSuffixErr  error
+)
+
+// NGMemberFQDN builds a networkgroup member FQDN valid on the target platform:
+// label + "." + the first DNS suffix served on the public
+// /networkgroup/configuration route ("cc-ng.cloud" on the public platform), so
+// acceptance tests need no hardcoded suffix and keep working on deployments
+// with another one.
+func NGMemberFQDN(t *testing.T, label string) string {
+	t.Helper()
+
+	ngSuffixOnce.Do(func() {
+		endpoint := os.Getenv("CC_API_ENDPOINT")
+		if endpoint == "" {
+			endpoint = "https://api.clever-cloud.com"
+		}
+
+		res, err := http.Get(endpoint + "/networkgroup/configuration")
+		if err != nil {
+			ngSuffixErr = err
+			return
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			ngSuffixErr = fmt.Errorf("GET /networkgroup/configuration: status %d", res.StatusCode)
+			return
+		}
+
+		configuration := struct {
+			DNSSuffixes []string `json:"dnsSuffixes"`
+		}{}
+		if err := json.NewDecoder(res.Body).Decode(&configuration); err != nil {
+			ngSuffixErr = err
+			return
+		}
+		if len(configuration.DNSSuffixes) == 0 {
+			ngSuffixErr = fmt.Errorf("GET /networkgroup/configuration: empty dnsSuffixes")
+			return
+		}
+		ngSuffix = configuration.DNSSuffixes[0]
+	})
+
+	if ngSuffixErr != nil {
+		t.Fatalf("cannot resolve the networkgroup DNS suffix: %s", ngSuffixErr)
+	}
+	return label + "." + ngSuffix
+}

--- a/pkg/tmp/ng.go
+++ b/pkg/tmp/ng.go
@@ -76,6 +76,21 @@ func ListNetworkgroups(ctx context.Context, cc *client.Client, organisationID st
 	return client.Get[[]Networkgroup](ctx, cc, path)
 }
 
+// NetworkgroupConfiguration is the deployment-level networkgroups configuration:
+// a member domain name must end with a dot followed by one of DNSSuffixes
+// (e.g. "cc-ng.cloud" on the public platform).
+type NetworkgroupConfiguration struct {
+	DNSSuffixes []string `json:"dnsSuffixes"`
+}
+
+// GetNetworkgroupConfiguration fetches the deployment-level networkgroups
+// configuration. Public route, unversioned on purpose; deployments predating it
+// answer 404.
+// GET /networkgroup/configuration
+func GetNetworkgroupConfiguration(ctx context.Context, cc *client.Client) client.Response[NetworkgroupConfiguration] {
+	return client.Get[NetworkgroupConfiguration](ctx, cc, "/networkgroup/configuration")
+}
+
 // ListMembers lists all members in a networkgroup
 func ListMembers(ctx context.Context, cc *client.Client, organisationID, networkgroupID string) client.Response[[]Member] {
 	path := fmt.Sprintf("/v4/networkgroups/organisations/%s/networkgroups/%s/members", organisationID, networkgroupID)


### PR DESCRIPTION
## Problem

The platform validates a networkgroup member `domainName` against deployment-level DNS suffixes and rejects anything else with a 400 whose message does not name them (*A form field was malformed*). Our three networkgroup acceptance tests sent bare labels (`myapp`) and failed on every CI run; a user hitting the rule got the same opaque error at apply.

## Change

The platform now serves its allowed suffixes on a public, unversioned route:

```
GET https://api.clever-cloud.com/networkgroup/configuration
→ 200 {"dnsSuffixes": ["cc-ng.cloud"]}
```

- **Apply-time validation** — before creating a member, `SyncNetworkGroups` fetches the suffixes and checks each fqdn about to be created, failing with the allowed suffixes in the message. A deployment predating the route answers 404: validation is skipped and the create call remains the authority. Existing members are never re-checked, so a legacy name does not block an apply.
- **Error detail** — when a member creation is still refused, the API error context (field-level detail) is surfaced instead of the bare message.
- **Tests** — the three acceptance tests build their fqdn from the route instead of hardcoding a suffix, so they hold on any deployment (on-premise included). All three pass locally against production; they were failing on every run before this.
- `fqdn` attribute documentation updated (generated docs left to the docs-sync job).

## Verified

- `TestAccNG_withPeers` (92s), `TestAccOtoroshi_networkgroup` (24s), `TestAccPython_networkgroup` (12s): PASS against production.
- `go build ./...", `go vet`, unit tests pass.